### PR TITLE
Get acm source and channel from packagemanifest

### DIFF
--- a/deploy-acm/03-subscription.yml
+++ b/deploy-acm/03-subscription.yml
@@ -5,7 +5,7 @@ metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
 spec:
-  channel: "release-CHANGEME"
+  channel: "CHANGECHANNEL"
   name: advanced-cluster-management
-  source: redhat-operators
+  source: "CHANGESOURCE"
   sourceNamespace: openshift-marketplace

--- a/deploy-acm/deploy.sh
+++ b/deploy-acm/deploy.sh
@@ -9,6 +9,7 @@ set -m
 # uncomment it, change it or get it from gh-env vars (default behaviour: get from gh-env)
 # export KUBECONFIG=/root/admin.kubeconfig
 
+<<<<<<< HEAD
 if ./verify.sh; then
 
 	# Load common vars
@@ -16,7 +17,9 @@ if ./verify.sh; then
 
 	echo ">>>> Modify files to replace with pipeline info gathered"
 	echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-	sed -i "s/CHANGEME/${OC_ACM_VERSION}/g" 03-subscription.yml
+    ACM_SOURCE=$(oc get packagemanifest -n openshift-marketplace advanced-cluster-management -o jsonpath='{.status.catalogSource}')
+    ACM_CHANNEL=$(oc get packagemanifest -n openshift-marketplace advanced-cluster-management -o jsonpath='{.status.defaultChannel}')
+    sed -i -e "s/CHANGESOURCE/${ACM_SOURCE}/" -e "s/CHANGECHANNEL/${ACM_CHANNEL}/" 03-subscription.yml
 
 	echo ">>>> Deploy manifests to install ACM ${OC_ACM_VERSION}"
 	echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"


### PR DESCRIPTION
Get acm source and channel from packagemanifest, to avoid use of dedicated variable and remove need to maintain it