### PR TITLE
GHA for release management

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401, E402, E722, C901
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+
+      - uses: actions/setup-python@v2.3.0
+      - uses: actions/cache@v2.1.7
+        with:
+          path: |
+            ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('**/.pre-commit-config.yaml/*') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
+
+      - uses: actions/cache@v2.1.7
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic
+        with:
+          extra_plugins: |
+            @semantic-release/git
+            @semantic-release/changelog
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/exec
+            @semantic-release/git
+            @semantic-release/github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA }}

--- a/.github/workflows/update_semver.yml
+++ b/.github/workflows/update_semver.yml
@@ -1,0 +1,17 @@
+name: Update Semver
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  release:
+     types:
+       - published
+
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: haya14busa/action-update-semver@v1.2.1
+        with:
+          major_version_tag_only: false  # (optional, default is "false")

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = netifaces,requests,urllib3,yaml

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,23 @@
+{
+  "branch": "main",
+  "repositoryUrl": "git@github.com:rh-ecosystem-edge/ztp-pipeline-relocatable.git",
+  "tagFormat": "${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "./CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "pre-commit run --files CHANGELOG.md; pre-commit  run --files CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/git",
+    "@semantic-release/github"
+  ]
+}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
Use GHA for automating release tagging so that 'v1.0.0' automatically creates 'v1.0', 'v1', and newer tags will update the pointers