### PR TITLE
Fix extracting the kubeconfig for spoke.

### DIFF
--- a/deploy-ocs/deploy.sh
+++ b/deploy-ocs/deploy.sh
@@ -42,8 +42,7 @@ function extract_vars() {
 function extract_kubeconfig() {
     ## Extract the Spoke kubeconfig and put it on the shared folder
     export SPOKE_KUBECONFIG=${OUTPUTDIR}/kubeconfig-${1}
-    oc --kubeconfig=${KUBECONFIG_HUB} get secret -n $spoke $spoke-admin-kubeconfig -o jsonpath=‘{.data.kubeconfig}’ | base64 -di > ${SPOKE_KUBECONFIG}
-
+    oc --kubeconfig=${KUBECONFIG_HUB} extract -n $spoke secret/$spoke-admin-kubeconfig --to - > ${SPOKE_KUBECONFIG}
 }
 
 # Load common vars


### PR DESCRIPTION
The backticks didn't work.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>