### PR TITLE
fixing typo on Persisten in verify_preflight.sh

### DIFF
--- a/shared-utils/verify_preflight.sh
+++ b/shared-utils/verify_preflight.sh
@@ -97,7 +97,7 @@ echo ">>>> Verify the PV available"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 if [[ $(oc get pv | wc -l) -lt 3 ]]; then
     #TODO verify the PV size  and if does not exists, create it from disk
-    echo "Error: Persisten volumes not available in the hub"
+    echo "Error: Persistent volumes not available in the hub"
     exit 6
 fi
 


### PR DESCRIPTION
In error message there is a typo with **Persisten** correcting it to **Persistent**