### PR TITLE
Restore hub registry when not syncing

### DIFF
--- a/.github/workflows/deploy-ztp-hub.yml
+++ b/.github/workflows/deploy-ztp-hub.yml
@@ -68,16 +68,19 @@ jobs:
       - name: Deploy Internal Disconnected Registry
         run: |
           export WORKDIR=${GITHUB_WORKSPACE}
+          # Get if we're forcing or not sync
+          export SYNCORNOT=${{env.SYNC}}
+
           cd ${{env.DEPLOY_REGISTRY_DIR}}
           ./deploy.sh 'hub'
           # TODO: assuming that the disconnected registry is already deployed and keeping contents.
-          if [ "${{env.SYNC}}" == "yes" ]; then
+          if [ "${SYNCORNOT}" == "yes" ]; then
             ./ocp-sync.sh 'hub'
             ./olm-sync.sh 'hub'
             rm -fr /var/tmp/mirror-snapshot.tgz
           fi
           ./update-global-pullsecret.sh 'hub'
-          ./mirror-snapshot.sh 'hub'
+          ./mirror-snapshot.sh 'hub' ${SYNCORNOT}
 
 
   deploy-acm:

--- a/.github/workflows/deploy-ztp-hub.yml
+++ b/.github/workflows/deploy-ztp-hub.yml
@@ -73,13 +73,13 @@ jobs:
 
           cd ${{env.DEPLOY_REGISTRY_DIR}}
           ./deploy.sh 'hub'
+          ./update-global-pullsecret.sh 'hub'
           # TODO: assuming that the disconnected registry is already deployed and keeping contents.
           if [ "${SYNCORNOT}" == "yes" ]; then
             ./ocp-sync.sh 'hub'
             ./olm-sync.sh 'hub'
             rm -fr /var/tmp/mirror-snapshot.tgz
           fi
-          ./update-global-pullsecret.sh 'hub'
           ./mirror-snapshot.sh 'hub' ${SYNCORNOT}
 
 

--- a/.github/workflows/deploy-ztp-hub.yml
+++ b/.github/workflows/deploy-ztp-hub.yml
@@ -11,10 +11,10 @@ on:
       RUNNER:
         description: 'GitHub Action Runner Tag'
         required: true
-      SYNC:
-        description: 'Force re-sync and mirror the Hub? (yes/no)'
-        default: no
-        required: false
+      # SYNC:
+      #   description: 'Force re-sync and mirror the Hub? (yes/no)'
+      #   default: no
+      #   required: false
 
 
 env:
@@ -73,13 +73,17 @@ jobs:
 
           cd ${{env.DEPLOY_REGISTRY_DIR}}
           ./deploy.sh 'hub'
-          ./update-global-pullsecret.sh 'hub'
+
           # TODO: assuming that the disconnected registry is already deployed and keeping contents.
-          if [ "${SYNCORNOT}" == "yes" ]; then
-            ./ocp-sync.sh 'hub'
-            ./olm-sync.sh 'hub'
-            rm -fr /var/tmp/mirror-snapshot.tgz
-          fi
+          # if [ "${SYNCORNOT}" == "yes" ]; then
+          #   ./ocp-sync.sh 'hub'
+          #   ./olm-sync.sh 'hub'
+          #   rm -fr /var/tmp/mirror-snapshot.tgz
+          # fi
+
+          ./ocp-sync.sh 'hub'
+          ./olm-sync.sh 'hub'
+          ./update-global-pullsecret.sh 'hub'
           ./mirror-snapshot.sh 'hub' ${SYNCORNOT}
 
 

--- a/.github/workflows/deploy-ztp-spokes.yml
+++ b/.github/workflows/deploy-ztp-spokes.yml
@@ -109,14 +109,14 @@ jobs:
           export WORKDIR=${GITHUB_WORKSPACE}
           cd ${{env.DEPLOY_REGISTRY_DIR}}
           ./deploy.sh 'spoke'
-          ./update-global-pullsecret.sh 'spoke'
-
           if [ "${{env.SYNC}}" == "yes" ]; then
             ./ocp-sync.sh 'spoke'
             ./olm-sync.sh 'spoke'
           else
             ./mirror-snapshot.sh 'spoke'
           fi
+          ./update-global-pullsecret.sh 'spoke'
+
 
 
 

--- a/.github/workflows/deploy-ztp-spokes.yml
+++ b/.github/workflows/deploy-ztp-spokes.yml
@@ -109,13 +109,15 @@ jobs:
           export WORKDIR=${GITHUB_WORKSPACE}
           cd ${{env.DEPLOY_REGISTRY_DIR}}
           ./deploy.sh 'spoke'
+          ./update-global-pullsecret.sh 'spoke'
+
           if [ "${{env.SYNC}}" == "yes" ]; then
             ./ocp-sync.sh 'spoke'
             ./olm-sync.sh 'spoke'
           else
             ./mirror-snapshot.sh 'spoke'
           fi
-          ./update-global-pullsecret.sh 'spoke'
+
 
 
   deploy-icsp-spokes-post:

--- a/deploy-disconnected-registry/mirror-snapshot.sh
+++ b/deploy-disconnected-registry/mirror-snapshot.sh
@@ -136,24 +136,26 @@ if [[ ${MODE} == 'hub' ]]; then
     oc --kubeconfig=${KUBECONFIG_HUB} -n default cp /var/tmp/${SNAPSHOTFILE} ${HTTPD_POD}:${HTTPDPATH}/${SNAPSHOTFILE}
     echo ">> Mirroring the registry snapshot is done successfully"
 
-    if [[ ${SYNCORNOT} == 'no' ]]; then
-        # We told flow not to sync and we've the tarball
-        echo ">> As we're not syncing, we need to repopulate the registry with existing tarball"
+    # Cannot be used until the CatalogSource issue mentioned above is addressed
 
-        # Run on the target registry the command to download the snapshot (wget comes within busybox)
-        oc exec --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} ${REGISTRY_POD} -- curl -o /var/lib/registry/ocatopic.tgz ${URL}
+    # if [[ ${SYNCORNOT} == 'no' ]]; then
+    #     # We told flow not to sync and we've the tarball
+    #     echo ">> As we're not syncing, we need to repopulate the registry with existing tarball"
 
-        # Uncompress from the / folder
-        oc exec --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} ${REGISTRY_POD} -- tar xvzf /var/lib/registry/ocatopic.tgz -C /
+    #     # Run on the target registry the command to download the snapshot (wget comes within busybox)
+    #     oc exec --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} ${REGISTRY_POD} -- curl -o /var/lib/registry/ocatopic.tgz ${URL}
 
-        # Cleanup downloaded file
-        oc exec --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} ${REGISTRY_POD} -- rm -fv /var/lib/registry/ocatopic.tgz
+    #     # Uncompress from the / folder
+    #     oc exec --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} ${REGISTRY_POD} -- tar xvzf /var/lib/registry/ocatopic.tgz -C /
 
-        # Create catalog source for the hub
-        create_cs ${MODE}
+    #     # Cleanup downloaded file
+    #     oc exec --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} ${REGISTRY_POD} -- rm -fv /var/lib/registry/ocatopic.tgz
 
-        echo ">> Restoring registry tarball when not syncing it completed"
-    fi
+    #     # Create catalog source for the hub
+    #     create_cs ${MODE}
+
+    #     echo ">> Restoring registry tarball when not syncing it completed"
+    # fi
 
 elif [[ ${MODE} == 'spoke' ]]; then
     if [[ -z ${ALLSPOKES} ]]; then

--- a/deploy-disconnected-registry/mirror-snapshot.sh
+++ b/deploy-disconnected-registry/mirror-snapshot.sh
@@ -106,6 +106,12 @@ DOCKERPATH="/var/lib/registry/docker"
 HTTPDPATH="/var/www/html"
 
 if [[ ${MODE} == 'hub' ]]; then
+    # We found that hub requires to update the kubeconfig which is done inside the olm-sync.sh so this would mean either to rerun the same function or reorg
+    # As this is only useful for CI/CD deployments to save on time syncing, we leave the code but force it to be a full resync until we've decided on the path
+    # to approach this
+    # TODO: Do not force mode for hub UNTIL we've sorted out the pull secret update done in the olm-sync
+    export SYNCORNOT='yes'
+
     HTTPD_POD=$(oc --kubeconfig=${KUBECONFIG_HUB} get pod -n default -oname | grep httpd | head -1 | cut -d "/" -f2-)
     REGISTRY_POD=$(oc --kubeconfig=${KUBECONFIG_HUB} get pod -n ${REGISTRY} -l name=${REGISTRY} -oname | head -1 | cut -d "/" -f2-)
     # Execute from node with the http and store in httpd path

--- a/deploy-hub-configs/deploy.sh
+++ b/deploy-hub-configs/deploy.sh
@@ -22,14 +22,14 @@ if ./verify.sh; then
     HTTPSERVICE=$(oc get routes -n default | grep httpd-server-route | awk '{print $2}')
     sed -i "s/HTTPD_SERVICE/${HTTPSERVICE}/g" 04-agent-service-config.yml
     pull=$(oc get secret -n openshift-config pull-secret -ojsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq -c)
-    echo -n "  .dockerconfigjson: "\'$pull\' >> 05-pullsecrethub.yml
+    echo -n "  .dockerconfigjson: "\'$pull\' >>05-pullsecrethub.yml
     REGISTRY=kubeframe-registry
     LOCAL_REG="$(oc get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})" #TODO change it to use the global common variable importing here the source commons
     sed -i "s/CHANGEDOMAIN/${LOCAL_REG}/g" registryconf.txt
     CABUNDLE=$(oc get cm -n openshift-image-registry kube-root-ca.crt --template='{{index .data "ca.crt"}}')
     echo "  ca-bundle.crt: |" >>01_Mirror_ConfigMap.yml
     echo -n "${CABUNDLE}" | sed "s/^/    /" >>01_Mirror_ConfigMap.yml
-    echo "" >> 01_Mirror_ConfigMap.yml
+    echo "" >>01_Mirror_ConfigMap.yml
     cat registryconf.txt >>01_Mirror_ConfigMap.yml
     NEWTAG=${LOCAL_REG}/ocp4/openshift4:${OC_OCP_TAG}
     sed -i "s/CHANGE_SPOKE_CLUSTERIMAGESET/${CLUSTERIMAGESET}/g" 02-cluster_imageset.yml
@@ -57,8 +57,8 @@ if ./verify.sh; then
 
     echo ">>>> Wait for ACM and AI deployed successfully"
 
-
 else
+
     echo ">>>> This step is not neccesary, everything looks ready"
 fi
 


### PR DESCRIPTION
The Hub registry must be restored if there's an existing  tarball  and we're not syncing it again