### PR TITLE
Closes #82 - Adding function to copy the kubeconfig properly to the masters

### DIFF
--- a/finish-deployment/deploy.sh
+++ b/finish-deployment/deploy.sh
@@ -64,12 +64,12 @@ function save_files() {
     for master in 0 1 2
     do
         EXT_MAC_ADDR=$(yq eval ".spokes[${i}].${cluster}.master${master}.mac_ext_dhcp" ${SPOKES_FILE})
-        for agent in $(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${NS} agent -o name)
+        echo ""
+        echo ">>>> Copying ${cluster} Kubeconfig to Master ${master} Node"
+        for agent in $(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} agent -o name)
         do
             NODE_IP=$(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} ${agent} -o jsonpath="{.status.inventory.interfaces[?(@.macAddress==\"${EXT_MAC_ADDR}\")].ipV4Addresses[0]}")
             if [[ ! -z ${NODE_IP} ]];then
-                echo ""
-                echo ">>>> Copying ${cluster} Kubeconfig to Master Nodes"
                 echo "Master Node: ${master}"
                 echo "AGENT: ${agent}"
                 echo "BMC: ${EXT_MAC_ADDR}"


### PR DESCRIPTION
Adding function to copy the kubeconfig properly to the Spoke Master Nodes

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

# Description
Adding function to copy the kubeconfig properly to the Spoke Master Nodes

Fixes #82 

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update