### PR TITLE
fixing check after timeout on spoke deployment

### DIFF
--- a/deploy-spoke/verify.sh
+++ b/deploy-spoke/verify.sh
@@ -31,7 +31,7 @@ function check_aci() {
 
     if [ "${ready}" == "false" ]; then
         echo "Timeout waiting for AgentClusterInstall ${cluster} on condition .status.conditions.Completed"
-        echo "Expected: ${desired_status} Current: $(oc --kubeconfig=${KUBECONFIG_HUB} aci -n ${cluster} -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}')"
+        echo "Expected: ${desired_status} Current: $(oc --kubeconfig=${KUBECONFIG_HUB} get aci -n ${cluster} -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}')"
         exit 1
     else
         echo "AgentClusterInstall for ${cluster} verified"


### PR DESCRIPTION
Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

# Description

```
[deploy-spokes] >> Waiting for ACI
[deploy-spokes] Spoke: spoke0-cluster
[deploy-spokes] Current: Finalizing cluster installation
[deploy-spokes] Desired State: Cluster is Installed
[deploy-spokes]
[deploy-spokes] Timeout waiting for AgentClusterInstall spoke0-cluster on condition .status.conditions.Completed
[deploy-spokes] flags cannot be placed before plugin name: --kubeconfig=/workspace/ztp/kubeconfig
[deploy-spokes] Expected: True Current:

container step-deploy-spokes has failed  : [{"key":"StartedAt","value":"2022-03-15T15:45:55.015Z","type":3}]
```