### PR TITLE
UI: Patch existing AddressPool instead of creating a new one

### DIFF
--- a/ui/frontend/src/components/PersistPage/constants.ts
+++ b/ui/frontend/src/components/PersistPage/constants.ts
@@ -14,3 +14,5 @@ export const SSH_PRIVATE_KEY_SECRET = {
 };
 export const SSH_PRIVATE_KEY_SECRET_TITLE = 'Missing SSH private key';
 export const SSH_PRIVATE_KEY_SECRET_INCORRECT = 'Incorrect SSH key secret';
+
+export const ADDRESS_POOL_NAMESPACE = 'metallb';

--- a/ui/frontend/src/components/PersistPage/constants.ts
+++ b/ui/frontend/src/components/PersistPage/constants.ts
@@ -15,4 +15,5 @@ export const SSH_PRIVATE_KEY_SECRET = {
 export const SSH_PRIVATE_KEY_SECRET_TITLE = 'Missing SSH private key';
 export const SSH_PRIVATE_KEY_SECRET_INCORRECT = 'Incorrect SSH key secret';
 
+export const ADDRESS_POOL_ANNOTATION_KEY = 'metallb.universe.tf/address-pool';
 export const ADDRESS_POOL_NAMESPACE = 'metallb';

--- a/ui/frontend/src/components/PersistPage/persist.ts
+++ b/ui/frontend/src/components/PersistPage/persist.ts
@@ -9,10 +9,10 @@ export const persist = async (
   onSuccess: () => void,
 ) => {
   if (
-    (await saveIngress(setError, state.ingressIp)) &&
-    (await saveApi(setError, state.apiaddr)) &&
+    (await persistIdentityProvider(setError, state.username, state.password)) &&
     /* TODO: save domain here */
-    (await persistIdentityProvider(setError, state.username, state.password))
+    (await saveIngress(setError, state.ingressIp)) &&
+    /* Persist API at last*/ (await saveApi(setError, state.apiaddr))
   ) {
     console.error('TODO: The domain is not persisted.');
     // finished with success

--- a/ui/frontend/src/components/PersistPage/resourceTemplates.ts
+++ b/ui/frontend/src/components/PersistPage/resourceTemplates.ts
@@ -1,7 +1,6 @@
 import { Secret, SecretApiVersion, SecretKind } from '../../resources/secret';
 import { Service, ServiceApiVersion, ServiceKind } from '../../resources/service';
-
-export const ADDRESS_POOL_ANNOTATION_KEY = 'metallb.universe.tf/address-pool';
+import { ADDRESS_POOL_NAMESPACE } from './constants';
 
 export const ADDRESS_POOL_TEMPLATE = {
   apiVersion: 'metallb.io/v1alpha1',
@@ -9,7 +8,7 @@ export const ADDRESS_POOL_TEMPLATE = {
   metadata: {
     generateName: 'ztpfw-', // To be filled
     name: '',
-    namespace: '', // To be filled
+    namespace: ADDRESS_POOL_NAMESPACE,
   },
   spec: {
     protocol: 'layer2',


### PR DESCRIPTION
# Description
Ingress/API AddressPool resources are expected to be already pre-created by factory.
This patch patches existing resources if possible.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
