### PR TITLE
UI: Fix random failing of "yarn install" in CI

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: './ui/yarn.lock'
       - name: Install dependencies
-        run: yarn install 
+        run: yarn install
         working-directory: ./ui
       - name: Build code (includes tests)
         run: yarn build

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "setup": "./setup.sh",
     "clean": "(cd frontend && yarn clean) ; (cd backend && yarn clean)",
-    "postinstall": "concurrently 'cd frontend && yarn install' 'cd backend && yarn install' -n frontend,backend -c green,blue",
+    "postinstall": "cd frontend && yarn install && cd ../backend && yarn install",
     "start": "concurrently yarn:frontend yarn:backend -n frontend,backend -c green,blue",
     "deployprod": "./deployProd.sh",
     "prebuild": "yarn test",


### PR DESCRIPTION
Parallel execution of the "yarn install" fails in the GitHub actions. Let's execute it sequentially.
