### PR TITLE
Patch provisioning after all crs were created.

### DIFF
--- a/deploy-spoke/deploy.sh
+++ b/deploy-spoke/deploy.sh
@@ -16,10 +16,10 @@ if ! ./verify.sh 1; then
     echo ">>>> Deploy all the manifests using kustomize"
     echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 
-    oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"watchAllNamespaces": true}}'
-
     cd ${OUTPUTDIR}
     oc apply -k .
+
+    oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"watchAllNamespaces": true}}'
 
     echo "Verifying again the clusterDeployment"
     # Waiting for 166 min to have the cluster deployed


### PR DESCRIPTION
Patching the provisioning causes the metal3 pod to restart.
This interferes with creating bmh instances.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
