### PR TITLE
Force kubelet ip to always belong to 192.168.7.0 network

### DIFF
--- a/deploy-spoke/render_spokes.sh
+++ b/deploy-spoke/render_spokes.sh
@@ -66,6 +66,59 @@ kind: Namespace
 metadata:
   name: $CHANGE_SPOKE_NAME
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: extra-manifests
+  namespace: $CHANGE_SPOKE_NAME
+data:
+  99-hack-nodeip-configuration.yaml: |
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        name: hack-nodeip-configuration
+        labels:
+          machineconfiguration.openshift.io/role: master
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          systemd:
+            units:
+            - name: nodeip-configuration.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
+                # This only applies to VIP managing environments where the kubelet and crio IP
+                # address picking logic is flawed and may end up selecting an address from a
+                # different subnet or a deprecated address
+                Wants=network-online.target crio-wipe.service
+                After=network-online.target ignition-firstboot-complete.service crio-wipe.service
+                Before=kubelet.service crio.service
+                [Service]
+                # Need oneshot to delay kubelet
+                Type=oneshot
+                # Would prefer to do Restart=on-failure instead of this bash retry loop, but
+                # the version of systemd we have right now doesn't support it. It should be
+                # available in systemd v244 and higher.
+                ExecStart=/bin/bash -c " \
+                  until \
+                  /usr/bin/podman run --rm \
+                  --authfile /var/lib/kubelet/config.json \
+                  --net=host \
+                  --volume /etc/systemd/system:/etc/systemd/system:z \
+                  quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7c94e6c2564196855c3e9d47f1ac5bdee4c78059e36b0a83cd6a0e8d7e71ea10 \
+                  node-ip \
+                  set --retry-on-failure \
+                  192.168.7.1; \
+                  do \
+                  sleep 5; \
+                  done"
+                ExecStart=/bin/systemctl daemon-reload
+                [Install]
+                WantedBy=multi-user.target
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -86,6 +139,8 @@ spec:
   imageSetRef:
     name: $CHANGE_SPOKE_CLUSTERIMAGESET
   fips: true
+  manifestsConfigMapRef:
+    name: extra-manifests
   apiVIP: "$CHANGE_SPOKE_API"
   ingressVIP: "$CHANGE_SPOKE_INGRESS"
   networking:


### PR DESCRIPTION
# Description

Force kubelet ip to always belong to 192.168.7.0 network

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
