### PR TITLE
fix: MGMT-10096 - Avoid storage overcommit when OCS is deployed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CI_FOLDER = images
 PIPE_IMAGE = quay.io/ztpfw/pipeline
 UI_IMAGE = quay.io/ztpfw/ui
-BRANCH := $(shell git for-each-ref --format='%(objectname) %(refname:short)' refs/heads | awk "/^$$(git rev-parse HEAD)/ {print \$$2}")
+BRANCH := $(shell git for-each-ref --format='%(objectname) %(refname:short)' refs/heads | awk "/^$$(git rev-parse HEAD)/ {print \$$2}" | tr '[:upper:]' '[:lower:]' | tr '\/' '-')
 HASH := $(shell git rev-parse HEAD)
 RELEASE ?= latest
 FULL_PIPE_IMAGE_TAG=$(PIPE_IMAGE):$(BRANCH)

--- a/deploy-ocs/manifests/04-OCS-StorageCluster.yaml
+++ b/deploy-ocs/manifests/04-OCS-StorageCluster.yaml
@@ -19,7 +19,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 200Gi
+            storage: 50Gi
         storageClassName: localstorage-sc-block
         volumeMode: Block
     name: ocs-deviceset

--- a/hack/deploy-hub-local/create-vm.yml
+++ b/hack/deploy-hub-local/create-vm.yml
@@ -15,11 +15,11 @@ spoke{{ i }}-cluster-m{{ j }}:
     nic: enp2s0
     mac: aa:aa:aa:aa:{{ j }}{{ i }}:{{ j }}a
   disks:
-  - size: 200
-  - size: 200
-  - size: 200
-  - size: 200
-  - size: 200  
+  - size: 120
+  - size: 50
+  - size: 50
+  - size: 50
+  - size: 50  
 {% endfor %}
 {% endfor %}
 
@@ -36,9 +36,9 @@ spoke{{ i }}-cluster-w0:
     nic: enp2s0
     mac: aa:aa:aa:0{{ i }}:0{{ i }}:0a
   disks:
-  - size: 200
-  - size: 200
-  - size: 200
-  - size: 200
-  - size: 200  
+  - size: 120
+  - size: 50
+  - size: 50
+  - size: 50
+  - size: 50  
 {% endfor %}


### PR DESCRIPTION
This update will fix our virtual environments with just disk of 50Gb-x4 per node, we need to ensure we will not put more size than the hypervisor could host. This only applies where OCS is deployed, so only affects the Spoke

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes [MGMT-10096](https://issues.redhat.com/browse/MGMT-10096) (issue)

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested in Flavio3 Node, after 16h of use the spoke cluster behaves good.

![image (6)](https://user-images.githubusercontent.com/1569950/165701514-90853787-98a6-4570-baa6-8097aa7afd97.png)
![image (7)](https://user-images.githubusercontent.com/1569950/165701517-7a33e7a2-ed51-4a4a-a6ad-41101f762de5.png)
![image (8)](https://user-images.githubusercontent.com/1569950/165701518-3608fe89-d92a-4829-8628-ee7fcbfa3a17.png)

PS: The worker task failed it's another non-related issue

