### PR TITLE
fix: Root is not necessary to execute the bootstrap script, removing

### DIFF
--- a/pipelines/bootstrap.sh
+++ b/pipelines/bootstrap.sh
@@ -159,11 +159,6 @@ function clean_openshift_pipelines() {
 
 }
 
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
-  exit 1
-fi
-
 export BASEDIR=$(dirname "$0")
 export BRANCH=${1:-main}
 export WORKDIR=${BASEDIR}/ztp-pipeline-relocatable


### PR DESCRIPTION
Removing the need of impersonation on root to execute the `bootstrap.sh` script

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update
