### PR TITLE
Patch routes selectively

### DIFF
--- a/ui/backend/src/common/resources/deployment.ts
+++ b/ui/backend/src/common/resources/deployment.ts
@@ -1,0 +1,35 @@
+import { Metadata } from './metadata';
+import { IResource } from './resource';
+
+// /apis/apps/v1/namespaces/ztpfw-ui/deployments/ztpfw-ui'
+
+export type DeploymentApiVersionType = 'apps/v1';
+export const DeploymentApiVersion: DeploymentApiVersionType = 'apps/v1';
+
+export type DeploymentKindType = 'Deployment';
+export const DeploymentKind: DeploymentKindType = 'Deployment';
+
+export interface Deployment extends IResource {
+  apiVersion: DeploymentApiVersionType;
+  kind: DeploymentKindType;
+  metadata: Metadata;
+  spec?: {
+    template?: {
+      spec?: {
+        containers?: {
+          env: {
+            name: string;
+            value: string;
+          }[];
+          image: string;
+          volumes: {
+            name: string;
+            secret?: {
+              secretName: string;
+            };
+          }[];
+        }[];
+      };
+    };
+  };
+}

--- a/ui/backend/src/common/resources/index.ts
+++ b/ui/backend/src/common/resources/index.ts
@@ -6,3 +6,5 @@ export * from './service';
 export * from './status';
 export * from './ingress';
 export * from './route';
+export * from './oauthclient';
+export * from './deployment';

--- a/ui/backend/src/common/resources/index.ts
+++ b/ui/backend/src/common/resources/index.ts
@@ -8,3 +8,4 @@ export * from './ingress';
 export * from './route';
 export * from './oauthclient';
 export * from './deployment';
+export * from './pod';

--- a/ui/backend/src/common/resources/oauthclient.ts
+++ b/ui/backend/src/common/resources/oauthclient.ts
@@ -13,8 +13,6 @@ export interface OAuthClient extends IResource {
   apiVersion: OAuthClientApiVersionType;
   kind: OAuthClientKindType;
   metadata: Metadata;
-  spec?: {
-    redirectURIs?: string[];
-    secret: string;
-  };
+  redirectURIs?: string[];
+  secret?: string;
 }

--- a/ui/backend/src/common/resources/oauthclient.ts
+++ b/ui/backend/src/common/resources/oauthclient.ts
@@ -1,0 +1,20 @@
+import { Metadata } from './metadata';
+import { IResource } from './resource';
+
+// apis/oauth.openshift.io/v1/oauthclients/ztpfwoauth'
+
+export type OAuthClientApiVersionType = 'oauth.openshift.io/v1';
+export const OAuthClientApiVersion: OAuthClientApiVersionType = 'oauth.openshift.io/v1';
+
+export type OAuthClientKindType = 'OAuthClient';
+export const OAuthClientKind: OAuthClientKindType = 'OAuthClient';
+
+export interface OAuthClient extends IResource {
+  apiVersion: OAuthClientApiVersionType;
+  kind: OAuthClientKindType;
+  metadata: Metadata;
+  spec?: {
+    redirectURIs?: string[];
+    secret: string;
+  };
+}

--- a/ui/backend/src/common/resources/pod.ts
+++ b/ui/backend/src/common/resources/pod.ts
@@ -1,0 +1,28 @@
+import { Metadata } from './metadata';
+import { IResource } from './resource';
+
+export type PodApiVersionType = 'v1';
+export const PodApiVersion: PodApiVersionType = 'v1';
+
+export type PodKindType = 'Pod';
+export const PodKind: PodKindType = 'Pod';
+
+export interface Pod extends IResource {
+  apiVersion: PodApiVersionType;
+  kind: PodKindType;
+  metadata: Metadata;
+  spec?: {
+    containers?: {
+      env?: {
+        name: string;
+        value: string;
+      }[];
+    }[];
+  };
+  status?: {
+    conditions: {
+      status: string;
+      type: string;
+    }[];
+  };
+}

--- a/ui/backend/src/common/resources/route.ts
+++ b/ui/backend/src/common/resources/route.ts
@@ -13,5 +13,9 @@ export interface Route extends IResource {
   metadata: Metadata;
   spec?: {
     host?: string;
+    port?: unknown;
+    tls?: unknown;
+    to?: unknown;
+    wildcardPolicy?: unknown;
   };
 }

--- a/ui/backend/src/constants.ts
+++ b/ui/backend/src/constants.ts
@@ -1,8 +1,9 @@
 export const TLS_SECRET_NAMESPACE = 'openshift-config';
 
 // Route-prefix for this application.
-// TODO: Make it dynamic, this might varry over deployments
+// TODO: Make it dynamic, this might vary over deployments
 export const ZTPFW_UI_ROUTE_PREFIX = 'edge-cluster-setup';
+export const OAUTH_ROUTE_PREFIX = 'oauth-openshift';
 export const ZTPFW_ROUTE_NAME = 'ztpfw-ui';
 export const ZTPFW_DEPLOYMENT_NAME = 'ztpfw-ui';
 

--- a/ui/backend/src/constants.ts
+++ b/ui/backend/src/constants.ts
@@ -3,5 +3,8 @@ export const TLS_SECRET_NAMESPACE = 'openshift-config';
 // Route-prefix for this application.
 // TODO: Make it dynamic, this might varry over deployments
 export const ZTPFW_UI_ROUTE_PREFIX = 'edge-cluster-setup';
+export const ZTPFW_ROUTE_NAME = 'ztpfw-ui';
+export const ZTPFW_DEPLOYMENT_NAME = 'ztpfw-ui';
 
+export const ZTPFW_OAUTHCLIENT_NAME = 'ztpfwoauth';
 export const ZTPFW_NAMESPACE = 'ztpfw-ui';

--- a/ui/backend/src/endpoints/changeDomain.ts
+++ b/ui/backend/src/endpoints/changeDomain.ts
@@ -1,11 +1,20 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Request, Response } from 'express';
-import { ZTPFW_NAMESPACE, ZTPFW_UI_ROUTE_PREFIX } from '../constants';
+import { Route } from '../common';
+import {
+  ZTPFW_DEPLOYMENT_NAME,
+  ZTPFW_NAMESPACE,
+  ZTPFW_OAUTHCLIENT_NAME,
+  ZTPFW_ROUTE_NAME,
+  ZTPFW_UI_ROUTE_PREFIX,
+} from '../constants';
 import { DNS_NAME_REGEX, PatchType, ComponentRoute } from '../frontend-shared';
-import { getToken, unauthorized } from '../k8s';
+import { getToken, PostResponse, unauthorized } from '../k8s';
 import { ApiServerSpec, patchApiServerConfig } from '../resources/apiserver';
+import { getDeployment, patchDeployment } from '../resources/deployment';
 import { getIngressConfig, patchIngressConfig } from '../resources/ingress';
-import { getAllRoutes, patchRoute } from '../resources/route';
+import { getOAuthClient, patchOAuthClient } from '../resources/oauthclient';
+import { backupRoute, getRoute, patchRoute } from '../resources/route';
 import { createCertSecret, generateCertificate } from './generateCertificate';
 
 import { validateInput } from './utils';
@@ -40,7 +49,7 @@ const updateIngressComponentRoutes = async (
   domain: string,
   namePrefix: string,
   routeNamespace: string,
-): Promise<boolean> => {
+): Promise<string | undefined /* secretName */> => {
   const secretName = await createSelfSignedTlsSecret(res, token, domain, namePrefix);
   if (secretName) {
     const route = componentRoutes.find((r) => r.name === routeName);
@@ -65,83 +74,147 @@ const updateIngressComponentRoutes = async (
       ', serving certificate: ',
       secretName,
     );
-    return true;
   }
 
-  return false;
+  return secretName;
 };
 
-const updateRoutes = async (
+const updateSingleRoute = async (
   token: string,
-  _ingressDomain: string,
-  _oldIngressDomain?: string,
-): Promise<boolean> => {
-  if (!_oldIngressDomain) {
-    logger.info('Missing old Ingress domain - skipping update of Route resources.');
-    return false;
-  }
-  const oldIngressDomain = `.${_oldIngressDomain}`;
-  const ingressDomain = `.${_ingressDomain}`;
-  logger.debug(
-    `Updating all Route resources. From "${oldIngressDomain}" to "${ingressDomain}" wherever possible.`,
-  );
+  oldIngressDomain: string,
+  ingressDomain: string,
+  route: Route,
+): Promise<PostResponse<Route> | void> => {
+  if (route.spec?.host) {
+    const newHost = route.spec.host.replace(oldIngressDomain, ingressDomain);
+    if (newHost === route.spec.host) {
+      logger.debug(
+        `No change for the ${route.metadata.namespace}/${route.metadata.name} route, keeping host: "${newHost}".`,
+      );
+    } else {
+      const patch: PatchType[] = [
+        {
+          op: 'replace',
+          path: '/spec/host',
+          value: newHost,
+        },
+      ];
 
-  try {
-    const allRoutes = await getAllRoutes(token);
-    if (!allRoutes?.length) {
-      logger.error('Failed to retrieve list of all routes.');
-      return false;
-    }
-
-    const promises: Promise<void>[] = [];
-    allRoutes.forEach((route) => {
-      if (route.spec?.host) {
-        const newHost = route.spec.host.replace(oldIngressDomain, ingressDomain);
-        if (newHost === route.spec.host) {
+      try {
+        return patchRoute(
+          token,
+          { name: route.metadata.name || '', namespace: route.metadata.namespace || '' },
+          patch,
+        ).then((r) => {
           logger.debug(
-            `No change for the ${route.metadata.namespace}/${route.metadata.name} route, keeping host: "${newHost}".`,
+            `Route ${route.metadata.namespace}/${route.metadata.name} is patched, new host: ${newHost}`,
           );
-        } else {
-          const patch: PatchType[] = [
-            {
-              op: 'replace',
-              path: '/spec/host',
-              value: newHost,
-            },
-          ];
-
-          const patching = async () => {
-            try {
-              await patchRoute(
-                token,
-                { name: route.metadata.name || '', namespace: route.metadata.namespace || '' },
-                patch,
-              );
-              logger.debug(
-                `Route ${route.metadata.namespace}/${route.metadata.name} is patched, new host: ${newHost}`,
-              );
-            } catch (e) {
-              logger.error(
-                `Failed to patch ${route.metadata.namespace}/${route.metadata.name} route: `,
-                e,
-              );
-            }
-          };
-          promises.push(patching());
-        }
-      } else {
-        logger.debug(
-          `Skipping update of ${route.metadata.namespace}/${route.metadata.name} route, missing host there.`,
+          return r;
+        });
+      } catch (e) {
+        logger.error(
+          `Failed to patch ${route.metadata.namespace}/${route.metadata.name} route: `,
+          e,
         );
       }
-    });
-
-    await Promise.allSettled(promises);
-  } catch (e) {
-    logger.error('Failed to patch routes: ', e);
-    return false;
+    }
+  } else {
+    logger.debug(
+      `Skipping update of ${route.metadata.namespace}/${route.metadata.name} route, missing host there.`,
+    );
   }
-  return true;
+};
+
+const updateZtpfwUI = async (
+  token: string,
+  // ztpfwUiTlsSecretName: string,
+  ztpfwDomain: string,
+  ingressDomain: string,
+  oldIngressDomain = '',
+) => {
+  // route
+  try {
+    const route = await getRoute(token, { name: ZTPFW_ROUTE_NAME, namespace: ZTPFW_NAMESPACE });
+
+    // Make a copy to be able to make livenessProbe requests from browser (new route hots CORS issue)
+    await backupRoute(token, route);
+    
+    await updateSingleRoute(token, oldIngressDomain, ingressDomain, route);
+    logger.debug('ZTPFW UI Route patched');
+  } catch (e) {
+    logger.error('Failed to patch ZTPFW UI Route: ', e);
+  }
+
+  // oauth-client
+  const newOauthRedirectUri = `https://${ztpfwDomain}/login/callback`;
+  try {
+    const oauthClient = await getOAuthClient(token, ZTPFW_OAUTHCLIENT_NAME);
+
+    const redirectURIs = oauthClient.spec?.redirectURIs || [];
+    if (!redirectURIs.includes(newOauthRedirectUri)) {
+      redirectURIs.push(newOauthRedirectUri);
+    }
+    const patchesOauth: PatchType[] = [
+      {
+        op: oauthClient.spec?.redirectURIs ? 'replace' : 'add',
+        path: '/spec/redirectURIs',
+        value: redirectURIs,
+      },
+    ];
+    await patchOAuthClient(token, ZTPFW_OAUTHCLIENT_NAME, patchesOauth);
+    logger.debug('ZTPFW UI OAuthClient patched');
+  } catch (e) {
+    logger.error('Failed to patch ZTPFW UI OAuthClient: ', e);
+  }
+
+  // Deployment
+  try {
+    const deployment = await getDeployment(token, {
+      name: ZTPFW_DEPLOYMENT_NAME,
+      namespace: ZTPFW_NAMESPACE,
+    });
+    logger.debug('ZTPFW Deployment received: ', deployment);
+    const env = deployment.spec?.template?.spec?.containers?.[0].env;
+    if (!env) {
+      logger.error(
+        'Can not find either env variables or volumes in the ZTPFW UI Deployment resource',
+      );
+      return;
+    }
+    const frontendEnv = env.find((e) => e.name === 'FRONTEND_URL');
+    if (frontendEnv) {
+      frontendEnv.value = `https://${ztpfwDomain}`;
+    } else {
+      logger.warn('Can not find FRONTEND_URL env variable in the ZTPFW UI Deployment resource');
+    }
+    const redirectEnv = env.find((e) => e.name === 'OAUTH2_REDIRECT_URL');
+    if (redirectEnv) {
+      redirectEnv.value = newOauthRedirectUri;
+    } else {
+      logger.warn(
+        'Can not find OAUTH2_REDIRECT_URL env variable in the ZTPFW UI Deployment resource',
+      );
+    }
+
+    const patchesDeployment: PatchType[] = [
+      {
+        op: 'replace',
+        path: '/spec/template/spec/containers',
+        value: deployment.spec?.template?.spec?.containers,
+      },
+    ];
+    await patchDeployment(
+      token,
+      {
+        name: ZTPFW_DEPLOYMENT_NAME,
+        namespace: ZTPFW_NAMESPACE,
+      },
+      patchesDeployment,
+    );
+    logger.debug('ZTPFW UI Deployment patched: ', patchesDeployment);
+  } catch (e) {
+    logger.error('Failed to patch ZTPFW UI Deployment: ', e);
+  }
 };
 
 /**
@@ -161,11 +234,16 @@ const updateRoutes = async (
  *     - update relevant item of the spec.componentRoutes
  *   - update spec.domain
  *
- * - update spec.host of all routes (in _all_ namespaces) if old value matches old domain (skip otherwise)
- *
- * - at last (to mitigate the risks), call HTTP PATCH on
+ * - call HTTP PATCH on
  *   - apiserver/cluster
  *   - ingress/cluster
+ *
+ * - update ZTPFW UI
+ *   - the route resource for the new domain
+ *   - OAuthClient for login callback
+ *   - Deployment for env variables
+ *   - side-effect: our pod is terminated (consequence of the Deployment resource change)
+ *
  */
 const changeDomainImpl = async (res: Response, token: string, _domain?: string): Promise<void> => {
   const domain = validateInput(DNS_NAME_REGEX, _domain);
@@ -219,40 +297,35 @@ const changeDomainImpl = async (res: Response, token: string, _domain?: string):
   const ztpfwDomain = `${ZTPFW_UI_ROUTE_PREFIX}.${ingressDomain}`;
 
   const componentRoutes = ingress?.spec?.componentRoutes || [];
-  if (
-    !(
-      (
-        (await updateIngressComponentRoutes(
-          res,
-          token,
-          componentRoutes,
-          'console',
-          consoleDomain,
-          'console-secret-',
-          'openshift-console', // namespace
-        )) &&
-        (await updateIngressComponentRoutes(
-          res,
-          token,
-          componentRoutes,
-          'oauth-openshift',
-          oauthDomain,
-          'oauth-secret-',
-          'openshift-authentication',
-        )) &&
-        (await updateIngressComponentRoutes(
-          res,
-          token,
-          componentRoutes,
-          ZTPFW_UI_ROUTE_PREFIX,
-          ztpfwDomain,
-          'ztpfw-secret-',
-          ZTPFW_NAMESPACE,
-        ))
-      )
-      // TODO: Anything else??
-    )
-  ) {
+  const consoleTlsSecretName = await updateIngressComponentRoutes(
+    res,
+    token,
+    componentRoutes,
+    'console',
+    consoleDomain,
+    'console-secret-',
+    'openshift-console', // namespace
+  );
+  const oauthTlsSecretName = await updateIngressComponentRoutes(
+    res,
+    token,
+    componentRoutes,
+    'oauth-openshift',
+    oauthDomain,
+    'oauth-secret-',
+    'openshift-authentication',
+  );
+  const ztpfwUiTlsSecretName = await updateIngressComponentRoutes(
+    res,
+    token,
+    componentRoutes,
+    ZTPFW_UI_ROUTE_PREFIX,
+    ztpfwDomain,
+    'ztpfw-secret-',
+    ZTPFW_NAMESPACE,
+  );
+  if (!(consoleTlsSecretName && oauthTlsSecretName && ztpfwUiTlsSecretName)) {
+    // TODO: Anything else??
     logger.info('Update of an ingress component route failed, exiting.');
     return;
   }
@@ -271,7 +344,8 @@ const changeDomainImpl = async (res: Response, token: string, _domain?: string):
   ];
 
   // Keep going even if a route fails to be updated. To have at least something
-  await updateRoutes(token, ingressDomain, oldIngressDomain);
+  // await updateRoutes(token, ingressDomain, oldIngressDomain);
+  logger.info('Skipping update of _all_ routes');
 
   // Persist the changes (call PATCH)
   try {
@@ -310,6 +384,14 @@ const changeDomainImpl = async (res: Response, token: string, _domain?: string):
     res.writeHead(500, 'Failed to patch ApiServer cluster resource.').end();
     return;
   }
+
+  // This will terminate our pod
+  await updateZtpfwUI(
+    token,
+    /*ztpfwUiTlsSecretName,*/ ztpfwDomain,
+    ingressDomain,
+    oldIngressDomain,
+  );
 
   res.writeHead(200).end(); // All good
 };

--- a/ui/backend/src/endpoints/readiness.ts
+++ b/ui/backend/src/endpoints/readiness.ts
@@ -1,13 +1,18 @@
+import { liveness } from "./liveness";
+
+/*
 import { Request, Response } from 'express';
 
 import { respondInternalServerError, respondOK } from '../k8s/respond';
-import { isLive } from './liveness';
+import { isLive, liveness } from './liveness';
 import { getOauthInfoPromise } from '../k8s/oauth';
 
 // The kubelet uses readiness probes to know when a container is ready to start accepting traffic
 export async function readiness(req: Request, res: Response): Promise<void> {
   if (!isLive) return respondInternalServerError(req, res);
-  const oauthInfo = await getOauthInfoPromise();
+  const oauthInfo = getOauthInfoPromise();
   if (!oauthInfo.authorization_endpoint) return respondInternalServerError(req, res);
   return respondOK(req, res);
 }
+*/
+export const readiness = liveness;

--- a/ui/backend/src/k8s/json-request.ts
+++ b/ui/backend/src/k8s/json-request.ts
@@ -81,14 +81,12 @@ export function jsonDelete<T = unknown>(
   const headers: HeadersInit = {};
   headers[HTTP2_HEADER_AUTHORIZATION] = `Bearer ${token}`;
 
-  console.log('--- jsonDelete: ', url);
   return fetchRetry(url, {
     method: 'DELETE',
     headers,
     agent,
     compress: true,
   }).then(async (response) => {
-    console.log('--- jsonDelete response: ', response);
     const result = {
       statusCode: response.status,
       body: (await response.json()) as unknown as T,

--- a/ui/backend/src/k8s/json-request.ts
+++ b/ui/backend/src/k8s/json-request.ts
@@ -73,3 +73,26 @@ export function jsonPatch<T = unknown>(
     return result;
   });
 }
+
+export function jsonDelete<T = unknown>(
+  url: string,
+  token: string,
+): Promise<PostResponse<T>> {
+  const headers: HeadersInit = {};
+  headers[HTTP2_HEADER_AUTHORIZATION] = `Bearer ${token}`;
+
+  console.log('--- jsonDelete: ', url);
+  return fetchRetry(url, {
+    method: 'DELETE',
+    headers,
+    agent,
+    compress: true,
+  }).then(async (response) => {
+    console.log('--- jsonDelete response: ', response);
+    const result = {
+      statusCode: response.status,
+      body: (await response.json()) as unknown as T,
+    };
+    return result;
+  });
+}

--- a/ui/backend/src/k8s/respond.ts
+++ b/ui/backend/src/k8s/respond.ts
@@ -38,6 +38,12 @@ export function respondCreated(res: Response, data: Record<string, unknown>): vo
 }
 
 export function redirect(res: Response, location: string): void {
+  // console.log(
+  //   '--- returning redirect, TODO: does it go with old or new domain? Why we are navigated to the old oauth domain??? res: ',
+  //   res,
+  //   ', location: ',
+  //   location,
+  // );
   res.writeHead(302, { location }).end();
 }
 

--- a/ui/backend/src/resources/deployment.ts
+++ b/ui/backend/src/resources/deployment.ts
@@ -1,0 +1,25 @@
+import { Deployment, DeploymentApiVersion } from '../common';
+import { PatchType } from '../frontend-shared';
+import { getClusterApiUrl, jsonPatch, jsonRequest } from '../k8s';
+
+// /apis/apps/v1/namespaces/ztpfw-ui/deployments/ztpfw-ui'
+export const getDeployment = async (token: string, metadata: { name: string; namespace: string }) =>
+  await jsonRequest<Deployment>(
+    `${getClusterApiUrl()}/apis/${DeploymentApiVersion}/namespaces/${
+      metadata.namespace
+    }/deployments/${metadata.name}`,
+    token,
+  );
+
+export const patchDeployment = (
+  token: string,
+  metadata: { name: string; namespace: string },
+  patches: PatchType[],
+) =>
+  jsonPatch<Deployment>(
+    `${getClusterApiUrl()}/apis/${DeploymentApiVersion}/namespaces/${
+      metadata.namespace
+    }/deployments/${metadata.name}`,
+    patches,
+    token,
+  );

--- a/ui/backend/src/resources/oauthclient.ts
+++ b/ui/backend/src/resources/oauthclient.ts
@@ -1,0 +1,17 @@
+import { OAuthClient, OAuthClientApiVersion } from '../common';
+import { PatchType } from '../frontend-shared';
+import { getClusterApiUrl, jsonPatch, jsonRequest } from '../k8s';
+
+// apis/oauth.openshift.io/v1/oauthclients/ztpfwoauth
+export const getOAuthClient = async (token: string, name: string) =>
+  await jsonRequest<OAuthClient>(
+    `${getClusterApiUrl()}/apis/${OAuthClientApiVersion}/oauthclients/${name}`,
+    token,
+  );
+
+export const patchOAuthClient = (token: string, name: string, patches: PatchType[]) =>
+  jsonPatch<OAuthClient>(
+    `${getClusterApiUrl()}/apis/${OAuthClientApiVersion}/oauthclients/${name}`,
+    patches,
+    token,
+  );

--- a/ui/backend/src/resources/route.ts
+++ b/ui/backend/src/resources/route.ts
@@ -34,7 +34,7 @@ export const backupRoute = async (token: string, route: Route) => {
 
   const backupRouteName = `${name}-copy`;
   try {
-    await jsonDelete<Route>(getRouteUrl(namespace, name), token);
+    await jsonDelete<Route>(getRouteUrl(namespace, backupRouteName), token);
   } catch (e) {
     console.log('Attempt to delete route-backup failed. This is not an error: ', e);
   }
@@ -52,17 +52,18 @@ export const backupRoute = async (token: string, route: Route) => {
         host: route.spec?.host,
         port: route.spec?.port,
         tls: route.spec?.tls,
-        to: route.spec?.host,
+        to: route.spec?.to,
         wildcardPolicy: route.spec?.wildcardPolicy,
       },
     };
-    return await jsonPost<Route>(
+    await jsonPost<Route>(
       `${getClusterApiUrl()}/apis/${RouteApiVersion}/namespaces/${namespace}/routes`,
       routeCopy,
       token,
     );
+
+    logger.debug('Backup route created');
   } catch (e) {
     console.error(`Failed to create copy of ${namespace}/${name} route: `, e);
   }
-  return undefined;
 };

--- a/ui/backend/src/resources/route.ts
+++ b/ui/backend/src/resources/route.ts
@@ -1,6 +1,9 @@
+import { RouteKind } from '../common';
 import { PatchType, Route, RouteApiVersion } from '../frontend-shared';
-import { getClusterApiUrl, jsonPatch, jsonRequest } from '../k8s';
+import { getClusterApiUrl, jsonDelete, jsonPatch, jsonPost, jsonRequest } from '../k8s';
 import { ListResult } from './types';
+
+const logger = console;
 
 export const getAllRoutes = async (token: string) =>
   (
@@ -10,16 +13,56 @@ export const getAllRoutes = async (token: string) =>
     )
   ).items;
 
-// https://api.spoke0-cluster.alklabs.com:6443/apis/route.openshift.io/v1/namespaces/ztpfw-ui/routes/ztpfw-ui
+const getRouteUrl = (namespace: string, name: string) =>
+  `${getClusterApiUrl()}/apis/${RouteApiVersion}/namespaces/${namespace}/routes/${name}`;
+
+export const getRoute = async (token: string, metadata: { name: string; namespace: string }) =>
+  await jsonRequest<Route>(getRouteUrl(metadata.namespace, metadata.name), token);
+
 export const patchRoute = (
   token: string,
   metadata: { name: string; namespace: string },
   patches: PatchType[],
-) =>
-  jsonPatch<Route>(
-    `${getClusterApiUrl()}/apis/${RouteApiVersion}/namespaces/${metadata.namespace}/routes/${
-      metadata.name
-    }`,
-    patches,
-    token,
-  );
+) => jsonPatch<Route>(getRouteUrl(metadata.namespace, metadata.name), patches, token);
+
+export const backupRoute = async (token: string, route: Route) => {
+  const { namespace, name } = route.metadata;
+  if (!namespace || !name) {
+    logger.warn('backupRoute: no route provided');
+    return;
+  }
+
+  const backupRouteName = `${name}-copy`;
+  try {
+    await jsonDelete<Route>(getRouteUrl(namespace, name), token);
+  } catch (e) {
+    console.log('Attempt to delete route-backup failed. This is not an error: ', e);
+  }
+
+  try {
+    const routeCopy: Route = {
+      apiVersion: RouteApiVersion,
+      kind: RouteKind,
+      metadata: {
+        labels: route.metadata.labels,
+        name: backupRouteName,
+        namespace: namespace,
+      },
+      spec: {
+        host: route.spec?.host,
+        port: route.spec?.port,
+        tls: route.spec?.tls,
+        to: route.spec?.host,
+        wildcardPolicy: route.spec?.wildcardPolicy,
+      },
+    };
+    return await jsonPost<Route>(
+      `${getClusterApiUrl()}/apis/${RouteApiVersion}/namespaces/${namespace}/routes`,
+      routeCopy,
+      token,
+    );
+  } catch (e) {
+    console.error(`Failed to create copy of ${namespace}/${name} route: `, e);
+  }
+  return undefined;
+};

--- a/ui/frontend/src/components/ActionCountDown/index.tsx
+++ b/ui/frontend/src/components/ActionCountDown/index.tsx
@@ -1,0 +1,28 @@
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import React from 'react';
+
+export const ActionCountDown: React.FC<{ action: () => void; initial?: number }> = ({
+  action,
+  initial = 120,
+}) => {
+  const [counter, setCounter] = React.useState(initial);
+
+  React.useEffect(() => {
+    if (counter > 0) {
+      const timer = setInterval(() => setCounter(counter - 1), 1000);
+      return () => clearInterval(timer);
+    } else {
+      action();
+    }
+  }, [counter, action]);
+
+  return (
+    <>
+      ({counter}s
+      <Button variant={ButtonVariant.link} onClick={action}>
+        Try now
+      </Button>
+      )
+    </>
+  );
+};

--- a/ui/frontend/src/components/PersistPage/PersistPageBottom.tsx
+++ b/ui/frontend/src/components/PersistPage/PersistPageBottom.tsx
@@ -19,7 +19,6 @@ import { PersistErrorType } from './types';
 import { useK8SStateContext } from '../K8SStateContext';
 
 import './PersistPageBottom.css';
-import { ActionCountDown } from '../ActionCountDown';
 
 export const PersistPageBottom: React.FC = () => {
   const navigate = useNavigate();
@@ -78,7 +77,8 @@ export const PersistPageBottom: React.FC = () => {
             />
           </StackItem>
           <StackItem isFilled className="wizard-sublabel">
-            Settings succesfully saved.
+            Settings succesfully saved, waiting for them to take effect.
+            {/* TODO: Show spinner */}
           </StackItem>
         </>
       )}

--- a/ui/frontend/src/components/PersistPage/PersistPageBottom.tsx
+++ b/ui/frontend/src/components/PersistPage/PersistPageBottom.tsx
@@ -14,12 +14,12 @@ import {
   global_success_color_100 as successColor,
 } from '@patternfly/react-tokens';
 
-import { persist } from './persist';
+import { navigateToNewDomain, persist } from './persist';
 import { PersistErrorType } from './types';
-import { DELAY_BEFORE_FINAL_REDIRECT } from './constants';
 import { useK8SStateContext } from '../K8SStateContext';
 
 import './PersistPageBottom.css';
+import { ActionCountDown } from '../ActionCountDown';
 
 export const PersistPageBottom: React.FC = () => {
   const navigate = useNavigate();
@@ -34,12 +34,8 @@ export const PersistPageBottom: React.FC = () => {
     setRetry(false);
     setError(undefined);
 
-    persist(state, setError, () => {
-      setTimeout(() => {
-        navigate(`/wizard/final`);
-      }, DELAY_BEFORE_FINAL_REDIRECT);
-    });
-  }, [retry, setError, state, navigate]);
+    persist(state, setError, () => navigateToNewDomain(state.domain, '/wizard/final'));
+  }, [retry, setError, state]);
 
   return (
     <Stack className="persist-page-bottom" hasGutter>

--- a/ui/frontend/src/components/PersistPage/constants.ts
+++ b/ui/frontend/src/components/PersistPage/constants.ts
@@ -9,9 +9,10 @@ export const UI_POD_NOT_READY = 'Configuration UI pod is not ready';
 export const API_LIVENESS_FAILED_TITLE = 'API can not be reached';
 
 export const IDENTITY_PROVIDER_NAME = 'ztpfw-htpasswd-idp';
+export const ZTPFW_NAMESPACE = 'ztpfw-ui';
 
-export const DELAY_BEFORE_FINAL_REDIRECT = 2 * 1000;
-export const MAX_LIVENESS_CHECK_COUNT = 20; /* TODO: increase to 120 */
+export const DELAY_BEFORE_FINAL_REDIRECT = 10 * 1000;
+export const MAX_LIVENESS_CHECK_COUNT = 20; /* TODO: increase to 24 */
 
 export const SSH_PRIVATE_KEY_SECRET = {
   name: 'cluster-ssh-keypair',

--- a/ui/frontend/src/components/PersistPage/constants.ts
+++ b/ui/frontend/src/components/PersistPage/constants.ts
@@ -5,10 +5,13 @@ export const RESOURCE_FETCH_TITLE = 'Failed to read resource';
 export const PERSIST_IDP = 'Registering new identity HTPasswd provider failed.';
 export const KUBEADMIN_REMOVE = 'Kubeadmin removal failed.';
 export const PERSIST_DOMAIN = 'Changing domain failed.';
+export const UI_POD_NOT_READY = 'Configuration UI pod is not ready';
+export const API_LIVENESS_FAILED_TITLE = 'API can not be reached';
 
 export const IDENTITY_PROVIDER_NAME = 'ztpfw-htpasswd-idp';
 
 export const DELAY_BEFORE_FINAL_REDIRECT = 2 * 1000;
+export const MAX_LIVENESS_CHECK_COUNT = 20; /* TODO: increase to 120 */
 
 export const SSH_PRIVATE_KEY_SECRET = {
   name: 'cluster-ssh-keypair',
@@ -19,3 +22,5 @@ export const SSH_PRIVATE_KEY_SECRET_INCORRECT = 'Incorrect SSH key secret';
 
 export const ADDRESS_POOL_ANNOTATION_KEY = 'metallb.universe.tf/address-pool';
 export const ADDRESS_POOL_NAMESPACE = 'metallb';
+
+export const ZTPFW_UI_ROUTE_PREFIX = 'edge-cluster-setup';

--- a/ui/frontend/src/components/PersistPage/persistServices.ts
+++ b/ui/frontend/src/components/PersistPage/persistServices.ts
@@ -8,7 +8,6 @@ import {
   ADDRESS_POOL_ANNOTATION_KEY,
   ADDRESS_POOL_NAMESPACE,
   API_LIVENESS_FAILED_TITLE,
-  MAX_LIVENESS_CHECK_COUNT,
   MISSING_VALUE,
   RESOURCE_CREATE_TITLE,
   RESOURCE_PATCH_TITLE,
@@ -205,9 +204,7 @@ export const saveApi = async (
     return false;
   }
 
-  if (
-    !(await waitForLivenessProbe(`https://${window.location.hostname}`, MAX_LIVENESS_CHECK_COUNT))
-  ) {
+  if (!(await waitForLivenessProbe())) {
     setError({
       title: API_LIVENESS_FAILED_TITLE,
       message: 'Can not reach API on time.',

--- a/ui/frontend/src/components/PersistPage/utils.ts
+++ b/ui/frontend/src/components/PersistPage/utils.ts
@@ -1,0 +1,26 @@
+import { getRequest } from '../../resources';
+import { DELAY_BEFORE_FINAL_REDIRECT } from './constants';
+
+export const delay = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export const waitForLivenessProbe = async (ztpfwUrl: string, counter: number) => {
+  try {
+    // We can not check new domain for availability due to CORS
+    await delay(DELAY_BEFORE_FINAL_REDIRECT);
+    console.info('Checking livenessProbe');
+    await getRequest(`${ztpfwUrl}/livenessProbe`).promise;
+
+    return true;
+  } catch (e) {
+    console.info('ZTPFW UI is not yet ready: ', e);
+    if (counter > 0) {
+      await waitForLivenessProbe(ztpfwUrl, counter - 1);
+    } else {
+      console.error('ZTPFW UI did not turn ready, giving up');
+      return false;
+    }
+  }
+};

--- a/ui/frontend/src/components/PersistPage/utils.ts
+++ b/ui/frontend/src/components/PersistPage/utils.ts
@@ -1,12 +1,24 @@
 import { getRequest } from '../../resources';
-import { DELAY_BEFORE_FINAL_REDIRECT } from './constants';
+import { getPodsOfNamespace } from '../../resources/pod';
+import {
+  DELAY_BEFORE_FINAL_REDIRECT,
+  MAX_LIVENESS_CHECK_COUNT,
+  ZTPFW_NAMESPACE,
+  ZTPFW_UI_ROUTE_PREFIX,
+} from './constants';
 
 export const delay = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
 
-export const waitForLivenessProbe = async (ztpfwUrl: string, counter: number) => {
+export const waitForLivenessProbe = async (
+  counter = MAX_LIVENESS_CHECK_COUNT,
+  ztpfwUrl?: string,
+) => {
+  // This works thanks to the route backup
+  ztpfwUrl = ztpfwUrl || `https://${window.location.hostname}`;
+
   try {
     // We can not check new domain for availability due to CORS
     await delay(DELAY_BEFORE_FINAL_REDIRECT);
@@ -17,10 +29,49 @@ export const waitForLivenessProbe = async (ztpfwUrl: string, counter: number) =>
   } catch (e) {
     console.info('ZTPFW UI is not yet ready: ', e);
     if (counter > 0) {
-      await waitForLivenessProbe(ztpfwUrl, counter - 1);
+      await waitForLivenessProbe(counter - 1, ztpfwUrl);
     } else {
       console.error('ZTPFW UI did not turn ready, giving up');
       return false;
     }
   }
+};
+
+export const waitForZtpfwPodToBeRecreated = async (
+  counter = MAX_LIVENESS_CHECK_COUNT,
+  newDomain: string,
+): Promise<boolean> => {
+  console.log('Waiting for ZTPFW UI pod to be ready');
+  await delay(DELAY_BEFORE_FINAL_REDIRECT);
+
+  try {
+    const pods = await getPodsOfNamespace(ZTPFW_NAMESPACE).promise;
+
+    const readyPods = pods.filter((p) =>
+      p.status?.conditions?.find((c) => c.type === 'Ready' && c.status === 'True'),
+    );
+
+    const isNewPodReady = !!readyPods.find(
+      (p) =>
+        !!p.spec?.containers?.find(
+          (c) =>
+            !!c.env?.find(
+              (e) =>
+                e.name === 'FRONTEND_URL' &&
+                e.value === `https://${ZTPFW_UI_ROUTE_PREFIX}.apps.${newDomain}`,
+            ),
+        ),
+    );
+
+    if (isNewPodReady) {
+      return true;
+    }
+
+    if (counter > 0) {
+      return await waitForZtpfwPodToBeRecreated(counter - 1, newDomain);
+    }
+  } catch (e) {
+    console.error('Failed to query ZTPFW pods: ', e);
+  }
+  return false;
 };

--- a/ui/frontend/src/components/Settings/SettingsPageRight.tsx
+++ b/ui/frontend/src/components/Settings/SettingsPageRight.tsx
@@ -12,11 +12,12 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-import { persist, PersistErrorType } from '../PersistPage';
+import { navigateToNewDomain, persist, PersistErrorType } from '../PersistPage';
 import { IpTripletsSelector } from '../IpTripletsSelector';
 import { useK8SStateContext } from '../K8SStateContext';
 
 import './SettingsPageRight.css';
+import { ActionCountDown } from '../ActionCountDown';
 
 export const SettingsPageRight: React.FC<{
   isInitialEdit?: boolean;
@@ -59,6 +60,8 @@ export const SettingsPageRight: React.FC<{
   const onSuccess = () => {
     setError(null);
     setEdit(false);
+
+    navigateToNewDomain(domain, '/settings');
   };
 
   const onCancelEdit = () => {
@@ -157,6 +160,10 @@ export const SettingsPageRight: React.FC<{
               data-testid="settings-page-button-edit"
               variant={ButtonVariant.primary}
               onClick={() => setEdit(true)}
+              disabled={
+                /* wait for changes to take effect, do another change on the new page after redirection */
+                error === null
+              }
             >
               Edit
             </Button>

--- a/ui/frontend/src/components/Settings/SettingsPageRight.tsx
+++ b/ui/frontend/src/components/Settings/SettingsPageRight.tsx
@@ -17,7 +17,6 @@ import { IpTripletsSelector } from '../IpTripletsSelector';
 import { useK8SStateContext } from '../K8SStateContext';
 
 import './SettingsPageRight.css';
-import { ActionCountDown } from '../ActionCountDown';
 
 export const SettingsPageRight: React.FC<{
   isInitialEdit?: boolean;
@@ -149,11 +148,14 @@ export const SettingsPageRight: React.FC<{
               variant={AlertVariant.success}
               isInline
             >
-              All changes have been saved.
+              All changes have been saved, waiting for them to take effect.
+              {/* TODO: show spinner */}
             </Alert>
           </StackItem>
         )}
-        {error === undefined && <StackItem isFilled></StackItem>}
+        {error === undefined && (
+          <StackItem isFilled>{isSaving && <>Saving changes... {/* TODO: Spinner */}</>}</StackItem>
+        )}
         <StackItem className="settings-page-sumamary__item__footer">
           {!isEdit && (
             <Button

--- a/ui/frontend/src/index.tsx
+++ b/ui/frontend/src/index.tsx
@@ -20,4 +20,6 @@ ReactDOM.render(
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 // reportWebVitals();
 
+// For debugging - especially after domain change
 console.log('UI Backend URL: ', getBackendUrl());
+console.log('Frontend accessed at: ', window.location.href);

--- a/ui/frontend/src/resources/pod.ts
+++ b/ui/frontend/src/resources/pod.ts
@@ -1,0 +1,9 @@
+import { listNamespacedResources } from './resource-request';
+import { Pod, PodApiVersion, PodKind } from '../backend-shared';
+
+export const getPodsOfNamespace = (namespace: string) =>
+  listNamespacedResources<Pod>({
+    apiVersion: PodApiVersion,
+    kind: PodKind,
+    metadata: { namespace },
+  });


### PR DESCRIPTION
Avoid bling patching all of them.

TODO:
- [x] This needs more testing
- [x] Try to avoid Count Down by keeping a copy of the old UI route to be able to query livenessProbe
- [x] fix ssue with having old oauth redirect when issued from the new domain
- [x]  clean-up code

In a nutshell:
- remove blind update of all routes, modify them selectively
- be more talkative about progress in the UI (but this still needs improvement, i.e. progress bar)
- block UI transition to new domain on a serie of predicates to be met first
- implement first "blocking-predicate" - wait for ZTPFW UI pod to be ready and serving **new** domain
- when saving API IP change, block on failing livenessProbe
- comment-out deletion of kubeadmin (will be properly handled in #195)
- skip querying `/.well-known/oauth-authorization-server` for auth endpoint in favour of calculating it from cluster domain (kind of hardcoding) - did not work reliably after domain change
- make liveness/ready probes dependant on reaching API instead of auth server
- ztpfw-ui k8s project:
  - patch route, make a copy of old one to keep existing session working, so UI can keep checking progress (backup-route to be deleted in a follow-up)
  - patch oauthclient for new domain
  - patch Deployment (env variables there for new domain)