### PR TITLE
Fix systemd error when enabling sushy

### DIFF
--- a/hack/deploy-hub-local/lab-sushy.service
+++ b/hack/deploy-hub-local/lab-sushy.service
@@ -9,3 +9,6 @@ ExecStop=/usr/bin/pkill sushy
 ExecReload=/usr/bin/pkill sushy
 StandardOutput=syslog
 StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

When enabling sushy.service using lab-sushy.sh, systemd complains because the systemd unit does not have an Install section.

## Type of change

Please select the appropriate options:

- [X ] Bug fix (non-breaking change which fixes an issue)
