### PR TITLE
Do not disable csr-autoapprover service

### DIFF
--- a/deploy-spoke/csr_autoapprover.sh
+++ b/deploy-spoke/csr_autoapprover.sh
@@ -33,11 +33,3 @@ while [ ${count} -gt 0 ]; do
     sleep 20
 
 done
-
-if [ $(oc get csr | grep Approved | grep -v Issued | wc -l) -gt 0 ]; then
-    rm -f ${KUBECONFIG}
-    echo "Kubeconfig file removed"
-    systemctl disable csr-approver
-    echo "csr-approver service disabled"
-    exit 0
-fi


### PR DESCRIPTION
# Description

Do not delete the kubeconfig stored in the spoke filesystem, nor disable csr-approver.service.

In a later PR we'll modify the kubeconfig to not be system:admin but only have the csr-approver clusterrole.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
