### PR TITLE
MGMT-10240 - Mask crio-wipe systemd unit

### DIFF
--- a/deploy-spoke/render_spokes.sh
+++ b/deploy-spoke/render_spokes.sh
@@ -60,7 +60,7 @@ create_spoke_definitions() {
     export IGN_OVERRIDE_API_HOSTS=$(echo -n "${CHANGE_SPOKE_API} ${SPOKE_API_NAME}" | base64 -w0)
     export IGN_CSR_APPROVER_SCRIPT=$(base64 csr_autoapprover.sh -w0)
     export JSON_STRING_CFG_OVERRIDE_INFRAENV='{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/hosts", "append": [{"source": "data:text/plain;base64,'${IGN_OVERRIDE_API_HOSTS}'"}]}]}}'
-    export JSON_STRING_CFG_OVERRIDE_BMH='{"ignition":{"version":"3.2.0"},"systemd":{"units":[{"name":"csr-approver.service","enabled":true,"contents":"[Unit]\nDescription=CSR Approver\nAfter=network.target\n\n[Service]\nUser=root\nType=oneshot\nExecStart=/bin/bash -c /opt/bin/csr-approver.sh\n\n[Install]\nWantedBy=multi-user.target"}]},"storage":{"files":[{"path":"/opt/bin/csr-approver.sh","mode":492,"append":[{"source":"data:text/plain;base64,'${IGN_CSR_APPROVER_SCRIPT}'"}]}]}}'
+    export JSON_STRING_CFG_OVERRIDE_BMH='{"ignition":{"version":"3.2.0"},"systemd":{"units":[{"name":"csr-approver.service","enabled":true,"contents":"[Unit]\nDescription=CSR Approver\nAfter=network.target\n\n[Service]\nUser=root\nType=oneshot\nExecStart=/bin/bash -c /opt/bin/csr-approver.sh\n\n[Install]\nWantedBy=multi-user.target"},{"name":"crio-wipe.service","mask":true}]},"storage":{"files":[{"path":"/opt/bin/csr-approver.sh","mode":492,"append":[{"source":"data:text/plain;base64,'${IGN_CSR_APPROVER_SCRIPT}'"}]}]}}'
     # Generate the spoke definition yaml
     cat <<EOF >${OUTPUTDIR}/${cluster}-cluster.yaml
 ---

--- a/finish-deployment/deploy.sh
+++ b/finish-deployment/deploy.sh
@@ -61,22 +61,23 @@ function save_files() {
     i=${2}
     cp -f ${SPOKE_KUBECONFIG} ${SPOKE_KUBEADMIN_PASS} ${SPOKE_SAFE_FOLDER}
 
-    for master in $(echo $(seq 0 $(($(yq eval ".spokes[${i}].[]|keys" ${SPOKES_FILE} | grep master | wc -l) - 1)))); do
-        EXT_MAC_ADDR=$(yq eval ".spokes[${i}].${cluster}.master${master}.mac_ext_dhcp" ${SPOKES_FILE})
-        echo ""
-        echo ">>>> Copying ${cluster} Kubeconfig to Master ${master} Node"
-        for agent in $(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} agent -o name); do
-            NODE_IP=$(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} ${agent} -o jsonpath="{.status.inventory.interfaces[?(@.macAddress==\"${EXT_MAC_ADDR}\")].ipV4Addresses[0]}")
-            if [[ -n ${NODE_IP} ]]; then
-                echo "Master Node: ${master}"
-                echo "AGENT: ${agent}"
-                echo "BMC: ${EXT_MAC_ADDR}"
-                echo "IP: ${NODE_IP%%/*}"
-                echo ">>>>"
-                ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "mkdir -p ~/.kube"
-                copy_files_common "${SPOKE_KUBECONFIG}" "${NODE_IP%%/*}" "./.kube/config"
-            fi
-        done
+    for agent in $(oc get agents --kubeconfig=${KUBECONFIG_HUB} -n ${cluster} -o jsonpath='{.items[?(@.status.role=="master")].metadata.name}')
+    do
+        echo
+        SPOKE_NODE_NAME=$(oc --kubeconfig=${KUBECONFIG_HUB} get agent -n ${cluster} ${agent} -o jsonpath={.spec.hostname})
+        master=${SPOKE_NODE_NAME##*-}
+        MAC_EXT_DHCP=$(yq e ".spokes[${i}].${cluster}.master${master}.mac_ext_dhcp" ${SPOKES_FILE})
+        SPOKE_NODE_IP_RAW=$(oc --kubeconfig=${KUBECONFIG_HUB} get agent ${agent} -n ${cluster} --no-headers -o jsonpath="{.status.inventory.interfaces[?(@.macAddress==\"${MAC_EXT_DHCP%%/*}\")].ipV4Addresses[0]}")
+        NODE_IP=${SPOKE_NODE_IP_RAW%%/*}
+        if [[ -n ${NODE_IP} ]]; then
+            echo "Master Node: ${master}"
+            echo "AGENT: ${agent}"
+            echo "BMC: ${MAC_EXT_DHCP}"
+            echo "IP: ${NODE_IP%%/*}"
+            echo ">>>>"
+            ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "mkdir -p ~/.kube"
+            copy_files_common "${SPOKE_KUBECONFIG}" "${NODE_IP%%/*}" "./.kube/config"
+        fi
     done
 }
 
@@ -124,7 +125,7 @@ for spoke in ${ALLSPOKES}; do
     echo ">> Cluster: ${spoke}"
     check_cluster ${spoke}
     recover_spoke_rsa ${spoke}
-    recover_spoke_files ${spoke} $i
+    recover_spoke_files ${spoke} ${i}
     store_rsa_secrets ${spoke}
     #detach_cluster ${spoke}
     i=$((i + 1))


### PR DESCRIPTION
# Mask crio-wipe systemd unit

Masking this unit allows us to avoid the image cache deletion on the nodes once the enclosure is relocated.

The problem happens when a power cycle appears and the service crio-wipe deletes the node images stored in cache. 

This issue becomes a bigger issue, knowing that the cluster is disconnected and the nodes are using their own registry to boot the pods up.

This is the main reason for this improvement.

In addition I've refactored the save_files function using the @flaper87 method.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>

Fixes [MGMT-10240](https://issues.redhat.com/browse/MGMT-10240)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

- Needs Manual Testing on Flavio3
- Avoid CI Testing because of virtual worker deployment step broken (This step comes later)
