### PR TITLE
Check if any conflicting_daemon_pod exists

### DIFF
--- a/deploy-disconnected-registry/deploy.sh
+++ b/deploy-disconnected-registry/deploy.sh
@@ -50,28 +50,33 @@ function side_evict_error() {
         echo "No masters on ${status}"
     else
         conflicting_daemon_pod=$(oc --kubeconfig=${KUBEC} get pod -n openshift-machine-config-operator -o wide --no-headers | grep daemon | grep ${conflicting_node} | cut -f1 -d\ )
-        pattern_1="$(oc --kubeconfig=${KUBEC} logs -n openshift-machine-config-operator ${conflicting_daemon_pod} -c machine-config-daemon | grep drain.go | grep evicting | tail -1 | grep pods)"
-        pattern_2="$(oc --kubeconfig=${KUBEC} logs -n openshift-machine-config-operator ${conflicting_daemon_pod} -c machine-config-daemon | grep drain.go | grep "Draining failed" | tail -1 | grep pod)"
 
-        for log_entry in "${pattern_1}" "${pattern_2}"; do
-            if [[ -z ${log_entry} ]]; then
-                echo "No Conflicting LogEntry on ${conflicting_daemon_pod}"
-            else
-                echo ">> Conflicting LogEntry Found!!"
-                pod=$(echo ${log_entry##*pods/} | cut -d\" -f2)
-                conflicting_ns=$(oc --kubeconfig=${KUBEC} get pod -A | grep ${pod} | cut -f1 -d\ )
+        # Check if conflicting_daemon_pod is not empty
+        if [[ -z ${conflicting_daemon_pod} ]]; then
+            echo "No conflicting daemon pod exists in ${conflicting_node}"
+        else
+            pattern_1="$(oc --kubeconfig=${KUBEC} logs -n openshift-machine-config-operator ${conflicting_daemon_pod} -c machine-config-daemon | grep drain.go | grep evicting | tail -1 | grep pods)"
+            pattern_2="$(oc --kubeconfig=${KUBEC} logs -n openshift-machine-config-operator ${conflicting_daemon_pod} -c machine-config-daemon | grep drain.go | grep "Draining failed" | tail -1 | grep pod)"
 
-                echo ">> Clean Eviction triggered info: "
-                echo NODE: ${conflicting_node}
-                echo DAEMON: ${conflicting_daemon_pod}
-                echo NS: ${conflicting_ns}
-                echo LOG: ${log_entry}
-                echo POD: ${pod}
+            for log_entry in "${pattern_1}" "${pattern_2}"; do
+                if [[ -z ${log_entry} ]]; then
+                    echo "No Conflicting LogEntry on ${conflicting_daemon_pod}"
+                else
+                    echo ">> Conflicting LogEntry Found!!"
+                    pod=$(echo ${log_entry##*pods/} | cut -d\" -f2)
+                    conflicting_ns=$(oc --kubeconfig=${KUBEC} get pod -A | grep ${pod} | cut -f1 -d\ )
 
-                oc --kubeconfig=${KUBEC} delete pod -n ${conflicting_ns} ${pod} --force --grace-period=0
-            fi
-        done
+                    echo ">> Clean Eviction triggered info: "
+                    echo NODE: ${conflicting_node}
+                    echo DAEMON: ${conflicting_daemon_pod}
+                    echo NS: ${conflicting_ns}
+                    echo LOG: ${log_entry}
+                    echo POD: ${pod}
 
+                    oc --kubeconfig=${KUBEC} delete pod -n ${conflicting_ns} ${pod} --force --grace-period=0
+                fi
+            done
+        fi
     fi
 }
 


### PR DESCRIPTION
# Description

Check if conflicting_daemon_pod exists in order to avoid error logs like the following:

`[deploy-disconnected-registry : deploy-disconnected-registry] Waiting for MCP Updated field on: spoke
[deploy-disconnected-registry : deploy-disconnected-registry] >> Looking for eviction errors
[deploy-disconnected-registry : deploy-disconnected-registry] grep: ztpfw-spoke0-cluster-master-2: No such file or directory
[deploy-disconnected-registry : deploy-disconnected-registry] error: expected 'logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]'.
[deploy-disconnected-registry : deploy-disconnected-registry] POD or TYPE/NAME is a required argument for the logs command
[deploy-disconnected-registry : deploy-disconnected-registry] See 'oc logs -h' for help and examples
[deploy-disconnected-registry : deploy-disconnected-registry] error: expected 'logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]'.
[deploy-disconnected-registry : deploy-disconnected-registry] POD or TYPE/NAME is a required argument for the logs command
[deploy-disconnected-registry : deploy-disconnected-registry] See 'oc logs -h' for help and examples
[deploy-disconnected-registry : deploy-disconnected-registry] No Conflicting LogEntry on 
[deploy-disconnected-registry : deploy-disconnected-registry] No Conflicting LogEntry on `

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
