### PR TITLE
Add set-motd utility

### DIFF
--- a/hack/set-motd/README.md
+++ b/hack/set-motd/README.md
@@ -1,0 +1,37 @@
+# set-motd docs
+
+## Usage
+
+Usage: set-motd [set|unset|help]
+
+Set a custom message with the needed flags.
+
+```bash
+set [-motd string] [-user string] [-pr link] [-path /foo/bar]
+  - motd: set custom message
+  - user: set user using the server
+  - pr:	set pull-request being tested
+  - path: set custom path (Default: /etc/motd)
+```
+
+Unset the custom message with `set-motd unset`. This will the server´s motd to "Server free to use".
+
+Show usage with `set-motd help`
+
+## Default values
+
+path: /etc/motd
+user: ZTPFW Github Actions
+
+## Default output
+
+```plain
+user@localhost]$ ./set-motd set -user fbac -motd "I'm using this server until 2152 at 15:40" -pr https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/pull/249
+
+user@localhost]$  cat /etc/motd
+
+Updated at Wed May 11 15:12:25 CEST 2022
+I'm using this server until 2152 at 15:40
+Pull Request https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/pull/249 test initiated by fbac
+```
+

--- a/hack/set-motd/go.mod
+++ b/hack/set-motd/go.mod
@@ -1,0 +1,3 @@
+module set-motd
+
+go 1.16

--- a/hack/set-motd/main.go
+++ b/hack/set-motd/main.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+const (
+	helpMsg string = `
+	Usage: set-motd [set|unset|help]
+	
+	set [-motd string] [-user string] [-pr link] [-path /foo/bar]
+	  - motd: set custom message
+	  - user: set user using the server
+	  - pr:	set pull-request being tested
+	  - path: set custom path (Default: /etc/motd)
+	
+	unset
+	
+	help
+	
+	`
+
+	unsetHelpMsg string = `
+	Usage: set-motd unset
+	Clears /etc/motd
+	
+	`
+
+	setHelpMsg string = `
+	Usage: set-motd set [-motd string] [-user string] [-pr link]
+	  - motd: set custom message
+	  - user: set user using the server
+	  - pr:	set pull-request being tested
+	  - path: set custom path (Default: /etc/motd)
+	
+	`
+)
+
+type stringFlag struct {
+	set   bool
+	value string
+}
+
+func (sf *stringFlag) Set(x string) error {
+	sf.value = x
+	sf.set = true
+	return nil
+}
+
+func (sf *stringFlag) String() string {
+	return sf.value
+}
+
+func setMotd(motd *stringFlag, user *stringFlag, pr *stringFlag, customPath *stringFlag) {
+
+	if len(os.Args) == 2 || len(os.Args) > 10 {
+		fmt.Print(setHelpMsg)
+		os.Exit(1)
+	}
+
+	currentTime := time.Now()
+	var motdMsg string = fmt.Sprintf("Updated at %s\n", currentTime.Format(time.UnixDate))
+
+	if motd.set {
+		motdMsg = fmt.Sprintf("%s%s\n", motdMsg, motd.String())
+	}
+
+	if pr.set {
+		motdMsg = fmt.Sprintf("%sPull Request %s test initiated by %s\n", motdMsg, pr.String(), user.String())
+	}
+
+	if user.set && !pr.set {
+		motdMsg = fmt.Sprintf("%sUsed by %s\n", motdMsg, user.String())
+	}
+
+	// Clean file
+	var path string = customPath.String()
+	if err := os.Truncate(path, 0); err != nil {
+		log.Printf("Failed to truncate: %v", err)
+	}
+
+	// Open file
+	var f, err = os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	// Write motd
+	_, err = f.WriteString(motdMsg)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func unsetMotd() {
+	if len(os.Args) > 2 {
+		fmt.Print(unsetHelpMsg)
+		os.Exit(1)
+	}
+
+	// Clear file
+	if err := os.Truncate("/etc/motd", 0); err != nil {
+		log.Printf("Failed to truncate: %v", err)
+	}
+
+	// Open file
+	var f, err = os.OpenFile("/etc/motd", os.O_RDWR, 0644)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	// Write motd
+	var unsetMotd string = "Server free to use\n"
+	n, err := f.WriteString(unsetMotd)
+	if err != nil {
+		fmt.Println(err, n)
+		os.Exit(1)
+	}
+}
+
+func printHelp() {
+	fmt.Print(helpMsg)
+	os.Exit(1)
+}
+
+func main() {
+
+	var setVarMotd stringFlag
+	var setVarUser stringFlag
+	setVarUser.value = "ZTPFW Github Actions"
+	var setVarPR stringFlag
+	var setCustomPath stringFlag
+	setCustomPath.value = "/etc/motd"
+
+	setCmd := flag.NewFlagSet("set", flag.ExitOnError)
+	setCmd.Var(&setVarMotd, "motd", "Set MOTD")
+	setCmd.Var(&setVarUser, "user", "Set User")
+	setCmd.Var(&setVarPR, "pr", "Set Pull Request")
+	setCmd.Var(&setCustomPath, "path", "Set custom path, defaults to /etc/motd")
+
+	if len(os.Args) < 2 {
+		printHelp()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "set":
+		setCmd.Parse(os.Args[2:])
+		setMotd(&setVarMotd, &setVarUser, &setVarPR, &setCustomPath)
+	case "unset":
+		unsetMotd()
+	case "help":
+		printHelp()
+	default:
+		printHelp()
+	}
+}


### PR DESCRIPTION
# Description

Add a new feature: set-motd

This binary sets /etc/motd or a given custom path to a custom programmable message, so a given server will show the message that it's being used.

In the future:
- It will be installed by ansible hypervisor scripts in /root/bin/set-motd for manual use
- It will be invoked from CI to set the PR currently being tested.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
