### PR TITLE
feat(ci): set motd when a worker is in use

### DIFF
--- a/.github/workflows/set-motd.yml
+++ b/.github/workflows/set-motd.yml
@@ -1,0 +1,23 @@
+name: Set MOTD
+on:
+  pull_request_review:
+    types: [submitted, edited]
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+jobs:
+  full-stack-testing:
+    if: github.event.review.state == 'approved'  && !contains(github.event.label.name, 'skip-ci') || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ci')
+    runs-on: CI-pool
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set MOTD
+        run: |
+          /root/bin/set-motd set -user "ZTPFW Github Actions" -pr "${{ github.event.pull_request.number }}" -motd "${{ github.event.pull_request.pull_request }}"


### PR DESCRIPTION
# Description

New feature: Sets /etc/motd using /root/bin/set-motd when a job is in progress.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
