### PR TITLE
Re-enable worker after it was accidentally disabled

### DIFF
--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -96,10 +96,10 @@ spec:
   # Deploy Workers
   - name: deploy-workers
     taskRef:
-      name: spoke-deploy-workers
+      name: edgecluster-deploy-workers
     params:
-      - name: spokes-config
-        value: $(params.spokes-config)
+      - name: edgeclusters-config
+        value: $(params.edgeclusters-config)
       - name: kubeconfig
         value: $(params.kubeconfig)
       - name: ztp-container-image

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -93,24 +93,24 @@ spec:
       - name: ztp
         workspace: ztp
 
-
-  # - name: deploy-workers
-  #   taskRef:
-  #     name: edgecluster-deploy-workers
-  #   params:
-  #     - name: edgeclusters-config
-  #       value: $(params.edgeclusters-config)
-  #     - name: kubeconfig
-  #       value: $(params.kubeconfig)
-  #     - name: ztp-container-image
-  #       value: $(params.ztp-container-image)
-  #     - name: mock
-  #       value: $(params.mock)
-  #   runAfter:
-  #     - deploy-metallb
-  #   workspaces:
-  #     - name: ztp
-  #       workspace: ztp
+  # Deploy Workers
+  - name: deploy-workers
+    taskRef:
+      name: spoke-deploy-workers
+    params:
+      - name: spokes-config
+        value: $(params.spokes-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
+      - name: ztp-container-image
+        value: $(params.ztp-container-image)
+      - name: mock
+        value: $(params.mock)
+    runAfter:
+      - deploy-metallb
+    workspaces:
+      - name: ztp
+        workspace: ztp
 
   # Deploy ZTPFWUI
   - name: deploy-ui
@@ -145,7 +145,7 @@ spec:
       - name: mock
         value: $(params.mock)
     runAfter:
-      # - deploy-workers
+      - deploy-workers
       - deploy-ui
     workspaces:
       - name: ztp


### PR DESCRIPTION
# Description

Workers were accidentally commented out while working on the GPU feature

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
