### PR TITLE
fix(setmotd): removing max args in setmotd set

### DIFF
--- a/hack/set-motd/main.go
+++ b/hack/set-motd/main.go
@@ -56,6 +56,12 @@ func (sf *stringFlag) String() string {
 }
 
 func setMotd(motd *stringFlag, user *stringFlag, pr *stringFlag, customPath *stringFlag) {
+
+	if len(os.Args) == 2 {
+		fmt.Print(setHelpMsg)
+		os.Exit(1)
+	}
+
 	currentTime := time.Now()
 	motdMsg := fmt.Sprintf("Updated at %s\n", currentTime.Format(time.UnixDate))
 

--- a/hack/set-motd/main.go
+++ b/hack/set-motd/main.go
@@ -56,12 +56,6 @@ func (sf *stringFlag) String() string {
 }
 
 func setMotd(motd *stringFlag, user *stringFlag, pr *stringFlag, customPath *stringFlag) {
-
-	if len(os.Args) == 2 || len(os.Args) > 10 {
-		fmt.Print(setHelpMsg)
-		os.Exit(1)
-	}
-
 	currentTime := time.Now()
 	motdMsg := fmt.Sprintf("Updated at %s\n", currentTime.Format(time.UnixDate))
 


### PR DESCRIPTION
# Description

Fixed the amount of args "set-motd set" can receive, we don ´t need an upper limit since -motd should receive messages as long as needed.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] main_test.go

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
