### PR TITLE
fix(ansible): clean repo before cloning

### DIFF
--- a/hack/deploy-hub-local/ansible/tasks/base/02-bin-utils.yaml
+++ b/hack/deploy-hub-local/ansible/tasks/base/02-bin-utils.yaml
@@ -17,6 +17,12 @@
     mode: "0755"
   tags: [ 02-bin-utils ]
 
+- name: Clean previous ztp sources
+  file:
+    path: /root/src/ztp
+    state: absent
+  tags: [ 02-bin-utils ]
+
 - name: Download ztp repo
   git:
     repo: https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable.git


### PR DESCRIPTION
# Description

When re-running the playbook it fails in the git clone step because the dest dir already exist. 

This change ensures the previous code is deleted before cloning again.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
