### PR TITLE
fix(ansible): bashrc messages break ansible

### DIFF
--- a/hack/deploy-hub-local/ansible/tasks/files/bashrc
+++ b/hack/deploy-hub-local/ansible/tasks/files/bashrc
@@ -23,4 +23,3 @@ function isSvn {
 
 export PS1="\[\e[0;35m\]\u:\[\e[0;35m\]\h \[\e[0;35m\]\[\e[0;32m\]: \w \[\e[1;31m\]\$(hasBranch)\$(isSvn) \n\[\e[0;35m\]\$ \[\e[0m\]"
 export RUNNER_ALLOW_RUNASROOT="1"
-echo -e "\nSet or unset current server's current status:\nset-motd set [-user] [-motd] [-pr]\nset-motd unset"


### PR DESCRIPTION
# Description

For some reason having an 'echo -e "x"' in .bashrc breaks ansible and it cannot retrieve the python interpreter correctly or any of the setup variables. 
Reverting this change from main and it will be tested extensively in dev branch.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
