### PR TITLE
fix(api): use nmstate.io/v1 instead of v1beta1

### DIFF
--- a/deploy-metallb/manifests/04-NMS-Operand.yaml
+++ b/deploy-metallb/manifests/04-NMS-Operand.yaml
@@ -1,4 +1,4 @@
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NMState
 metadata:
   name: nmstate

--- a/deploy-metallb/manifests/nncp.yaml
+++ b/deploy-metallb/manifests/nncp.yaml
@@ -1,4 +1,4 @@
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: $NODENAME-nncp

--- a/finish-deployment/manifests/nmstate.yaml
+++ b/finish-deployment/manifests/nmstate.yaml
@@ -1,4 +1,4 @@
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NMState
 metadata:
   name: nmstate

--- a/finish-deployment/manifests/nncp.yaml
+++ b/finish-deployment/manifests/nncp.yaml
@@ -1,4 +1,4 @@
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: $NODENAME-nncp


### PR DESCRIPTION
# Description

Use the api nmstate.io/v1 instead of the deprecated nmstate.io/v1beta1 to get rid of the deprecation warning.

Fixes # [(issue)](https://issues.redhat.com/browse/MGMT-10369)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
