### PR TITLE
feat(ansible): add hub kubeconfig alias to bashrc

### DIFF
--- a/hack/deploy-hub-local/ansible/tasks/files/bashrc
+++ b/hack/deploy-hub-local/ansible/tasks/files/bashrc
@@ -5,6 +5,7 @@
 alias rm='rm -i'
 alias cp='cp -i'
 alias mv='mv -i'
+alias hub='export KUBECONFIG=/root/.kcli/clusters/test-ci/auth/kubeconfig'
 
 # Source global definitions
 if [ -f /etc/bashrc ]; then


### PR DESCRIPTION
# Description

Add an alias "hub" to export the kubeconfig hypervisor provisioned by our ansible playbooks.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
