### PR TITLE
feat(ansible): add function edge to export edge's kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0](https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/compare/1.4.5...1.5.0) (2022-05-18)
+
+### Features
+
+- **ansible:** add hub kubeconfig alias to bashrc ([fbf4624](https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/commit/fbf4624fc61d9e790f354c4acdfcc10623cecff0))
+- **ci:** show in motd when a job has failed ([6a56d33](https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/commit/6a56d3354198c1be26438837228b85739e7e20f3))
+
 ## [1.4.5](https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/compare/1.4.4...1.4.5) (2022-05-18)
 
 ### Bug Fixes

--- a/hack/deploy-hub-local/ansible/tasks/files/bashrc
+++ b/hack/deploy-hub-local/ansible/tasks/files/bashrc
@@ -22,5 +22,16 @@ function isSvn {
     test -d .svn && echo "(svn)"
 }
 
+function edge {
+    hub
+    oc extract secret/edgecluster0-cluster-admin-kubeconfig -n edgecluster0-cluster --keys=kubeconfig --to=/root 1>/dev/null
+    if [ $? -ne 0 ]; then
+      echo "Error extracting Edge Cluster Kubeconfig"
+    else
+      mv -f /root/kubeconfig /root/edge-kubeconfig
+      export KUBECONFIG=/root/edge-kubeconfig
+    fi
+}
+
 export PS1="\[\e[0;35m\]\u:\[\e[0;35m\]\h \[\e[0;35m\]\[\e[0;32m\]: \w \[\e[1;31m\]\$(hasBranch)\$(isSvn) \n\[\e[0;35m\]\$ \[\e[0m\]"
 export RUNNER_ALLOW_RUNASROOT="1"


### PR DESCRIPTION
# Description

Add the function "edge" to /root/.bashrc.

With this every hypervisor provisioned by ansible will have the commands hub and edge to export automaticalle the hub/edge kubeconfig respectively.

## Type of change

Please select the appropriate options:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] PRs should not be merged unless positively reviewed.
