### PR TITLE
fix(registry): fix the registry route check

### DIFF
--- a/deploy-disconnected-registry/deploy.sh
+++ b/deploy-disconnected-registry/deploy.sh
@@ -146,7 +146,7 @@ function check_route_ready() {
     timeout=0
     ready=false
     while [ "$timeout" -lt "1000" ]; do
-        if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route -n ${REGISTRY} --no-headers | wc -l) -eq 3 ]]; then
+        if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route -n ${REGISTRY} --no-headers | wc -l) -ge 3 ]]; then
             ready=true
             break
         fi


### PR DESCRIPTION
# Description

This check expect the routes in the project ztpfw-registry to be exactly 3, which apparently now is incorrect (changes in quay operator?).

Now, it will check for 3 routes or more.

```
root:flavio2 : [system:admin@edge] ~  
$ oc get routes
NAME                                HOST/PORT                                                                                  PATH   SERVICES                            PORT    TERMINATION     WILDCARD
ztpfw-registry-quay                 ztpfw-registry-quay-ztpfw-registry.apps.edgecluster0-cluster.alklabs.local                        ztpfw-registry-quay-app             http    edge/Redirect   None
ztpfw-registry-quay-builder         ztpfw-registry-quay-builder-ztpfw-registry.apps.edgecluster0-cluster.alklabs.local                ztpfw-registry-quay-app             grpc    edge/Redirect   None
ztpfw-registry-quay-config-editor   ztpfw-registry-quay-config-editor-ztpfw-registry.apps.edgecluster0-cluster.alklabs.local          ztpfw-registry-quay-config-editor   http    edge/Redirect   None
ztpfw-registry-test-route           ztpfw-registry-test-route-ztpfw-registry.apps.edgecluster0-cluster.alklabs.local                  none                                <all>                   None
```

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
