### PR TITLE
feat(ci): set motd based on final workflow status

### DIFF
--- a/.github/workflows/testing-pr.yml
+++ b/.github/workflows/testing-pr.yml
@@ -151,9 +151,19 @@ jobs:
             exit 1
           fi
 
-      - name: Unset MOTD
+      - name: Unset MOTD if workflow succeeded
+        if: ${{ success() }}
         continue-on-error: true
         run: |
           if [ -f /root/bin/set-motd ]; then
             /root/bin/set-motd unset
+          fi
+      
+      - name: Unset MOTD if workflow failed
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          if [ -f /root/bin/set-motd ]; then
+              MOTD=$(printf "Title: ${{ github.event.pull_request.title }}\nAuthor: ${{ github.event.pull_request.user.login }}\nStatus: FAILURE! Check the logs!")
+              /root/bin/set-motd set -user "ZTPFW Github Actions" -pr "${{ github.event.pull_request.html_url }}" -motd "$MOTD"
           fi


### PR DESCRIPTION
# Description

Set/unset motd based on workflow final status:
- success() check if every preceding step succedded
- failure() check if any of the preceding steps failed

Based on those conditions, now:
- set host as free so it can be reused
- set host as failed, maybe util for debugging. [*]

[*] discussion to follow: should we do anything more if the check fail? Maybe gather logs, mark the runner as inactive until debug is performed, etc.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
