### PR TITLE
ci(testing-pr.yaml): skip UI generation errors to not block other tests

### DIFF
--- a/.github/workflows/testing-pr.yml
+++ b/.github/workflows/testing-pr.yml
@@ -51,6 +51,7 @@ jobs:
           RELEASE=${RELEASE} make pipe-image-ci
 
       - name: Build and Push UI Image
+        continue-on-error: true  # Workaround until the generation is fixed
         id: build-ui
         run: |
           cd ${{ github.workspace }}


### PR DESCRIPTION
# Description

Skip UI build generation errors in the meantime

related #332