### PR TITLE
fix: mgmt-10251-change default size vm and odf storagecluster manifest to 1 

### DIFF
--- a/deploy-odf/manifests/04-ODF-StorageCluster.yaml
+++ b/deploy-odf/manifests/04-ODF-StorageCluster.yaml
@@ -19,7 +19,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 75Gi
         storageClassName: localstorage-sc-block
         volumeMode: Block
     name: ocs-deviceset

--- a/deploy-odf/manifests/04-ODF-StorageCluster.yaml
+++ b/deploy-odf/manifests/04-ODF-StorageCluster.yaml
@@ -19,7 +19,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 75Gi
+            storage: 1
         storageClassName: localstorage-sc-block
         volumeMode: Block
     name: ocs-deviceset

--- a/hack/deploy-hub-local/create-vm.yml
+++ b/hack/deploy-hub-local/create-vm.yml
@@ -16,10 +16,10 @@ edgecluster{{ i }}-cluster-m{{ j }}:
     mac: aa:aa:aa:aa:{{ j }}{{ i }}:{{ j }}a
   disks:
   - size: 120
-  - size: 50
-  - size: 50
-  - size: 50
-  - size: 50  
+  - size: 75
+  - size: 75
+  - size: 75
+  - size: 75
 {% endfor %}
 {% endfor %}
 
@@ -37,8 +37,8 @@ edgecluster{{ i }}-cluster-w0:
     mac: aa:aa:aa:0{{ i }}:0{{ i }}:0a
   disks:
   - size: 120
-  - size: 50
-  - size: 50
-  - size: 50
-  - size: 50  
+  - size: 75
+  - size: 75
+  - size: 75
+  - size: 75
 {% endfor %}

--- a/hack/deploy-hub-local/create-vm.yml
+++ b/hack/deploy-hub-local/create-vm.yml
@@ -16,10 +16,10 @@ edgecluster{{ i }}-cluster-m{{ j }}:
     mac: aa:aa:aa:aa:{{ j }}{{ i }}:{{ j }}a
   disks:
   - size: 120
-  - size: 75
-  - size: 75
-  - size: 75
-  - size: 75
+  - size: 50
+  - size: 50
+  - size: 50
+  - size: 50
 {% endfor %}
 {% endfor %}
 
@@ -37,8 +37,8 @@ edgecluster{{ i }}-cluster-w0:
     mac: aa:aa:aa:0{{ i }}:0{{ i }}:0a
   disks:
   - size: 120
-  - size: 75
-  - size: 75
-  - size: 75
-  - size: 75
+  - size: 50
+  - size: 50
+  - size: 50
+  - size: 50
 {% endfor %}


### PR DESCRIPTION
Signed-off-by: Alberto Morgante Medina <alknopfler@users.noreply.github.com>

# Description

Change the VM disk and the request in the storagecluster manifest to 75gb disk size

Fixes # https://issues.redhat.com/browse/MGMT-10251

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually in Flavio1 to verify with @achuzhoy before testing with the CI
![image](https://user-images.githubusercontent.com/9356454/171592546-71b8ea7e-e177-4d6b-a312-426633b6fa29.png)

Also has been tested after a day just to ensure the size of disks is OK and not increasing
```
cluster:
    id:     e96b1089-7ca1-4434-8233-e604ffadc873
    health: HEALTH_OK  services:
    mon: 3 daemons, quorum a,b,c (age 2m)
    mgr: a(active, since 22h)
    mds: 1/1 daemons up, 1 hot standby
    osd: 12 osds: 12 up (since 21h), 12 in (since 23h)
    rgw: 1 daemon active (1 hosts, 1 zones)  data:
    volumes: 1/1 healthy
    pools:   11 pools, 465 pgs
    objects: 54.33k objects, 110 GiB
    usage:   341 GiB used, 559 GiB / 900 GiB avail
    pgs:     465 active+clean  io:
    client:   3.9 KiB/s rd, 9.6 KiB/s wr, 2 op/s rd, 2 op/s wr 
```
- [x] Test A - manually
- [x] Test B - pipe ci (https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/runs/6707673617?check_suite_focus=true)

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
