### PR TITLE
fix(edgeclusters.sh): Workaround BZ 2073197 issue with signatures on containers

### DIFF
--- a/images/Containerfile.pipeline
+++ b/images/Containerfile.pipeline
@@ -13,4 +13,7 @@ RUN curl -k -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/
 RUN dnf install -y bind-utils openssl openssh-clients httpd-tools conmon skopeo podman gettext fuse-overlayfs iputils nmap-ncat --setopt=install_weak_deps=False  && \
     dnf clean all &&  rm -rf /var/cache/yum
 
+# Workaround for BZ 2073197, GH https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/issues/354
+RUN echo '{"default":[{"type":"insecureAcceptAnything"}],"transports":{"docker-daemon":{"":[{"type":"insecureAcceptAnything"}]}}}' > /etc/containers/policy.json
+
 COPY . /opt/ztp


### PR DESCRIPTION
# Description
Override for BZ 2073197 to override permissions https://bugzilla.redhat.com/show_bug.cgi?id=2073197#c19


Related: https://github.com/openshift/machine-config-operator/issues/1349



Apparently, by mistake,  a change in  RHCOS image does try to verify signatures for the images, which are not currently mirrored or even provided, and this causes an issue.

There's an upstream issue listed to get this solved, but as a workaround we're disabling verification in Edge clusters via an ignition file and might in addition require a change in the installer image being used until RHCOS has the changes reverted and the related tooling is updated to mirror signatures, etc.