### PR TITLE
internal(clean-scripts): take in account more use cases and options

### DIFF
--- a/hack/clean/clean-libvirt-pool.sh
+++ b/hack/clean/clean-libvirt-pool.sh
@@ -10,10 +10,13 @@ resourcesUsed=""
 getUsedResources() {
     for vm in $(kcli list vm -o json | jq -r .[].name); do
         # preserve ISO/iso used by existing vm's
-        resourcesUsed=$(printf "%s|%s|${resourcesUsed}" "${vm}.ISO" "${vm}.iso")
+        resourcesUsed=$(printf "%s|${resourcesUsed}" "${vm}.ISO")
+
+        # some vm's have a boot-ID iso - depending on how they were created
+        resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep iso: | awk '{print $2}' | sed 's#\/var\/lib\/libvirt\/images\/##g')")
 
         # preserve images used by existing vm's
-        resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep image: | awk '{print $2}')")
+        resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep image: | awk '{print $2}' | sed 's#\/var\/lib\/libvirt\/images\/##g')")
 
         # preserve all disks used by existing vm's
         for disk in $(kcli show vm $vm | grep -E 'diskname:' | awk '{print $10}' | sed 's#\/var\/lib\/libvirt\/images\/##'); do
@@ -22,15 +25,40 @@ getUsedResources() {
     done
 }
 
+# get the resources
 getUsedResources
 
 # build a cmd that greps out the *used* resources
-# ensuring that resources in toDelete are *unused*
-resourcesGrep=$(echo $resourcesUsed | sed 's/.$//')
+# cmd has to guarantee resources in toDelete are *unused*
+# sanitize output by removing any trailing character
+# and also double || introduced by getUsedResources\
+# failing to do this will make cmd unusable and unreliable
+resourcesGrep=$(echo $resourcesUsed | sed 's/.$//' | sed 's/||/|/'g)
 cmd=$(printf "ls /var/lib/libvirt/images | grep -Ev '%s'" ${resourcesGrep})
 toDelete=$(eval $cmd)
 
-# delete unused resources
-for resource in $(echo $toDelete); do
-    kcli delete disk --novm --yes ${resource}
-done
+# dry-run will prompt the images to be deleted
+# now will wipe the pool
+case "${1}" in
+    'dry-run')
+        echo "############### ${0} dry-run"
+        echo "############### resources in use - won't be deleted"
+        echo $cmd
+        echo ""
+
+        echo "############### resources unused - will be delete"
+        for resource in $(echo $toDelete); do
+            echo $resource
+        done
+    ;;
+
+    'now')
+        for resource in $(echo $toDelete); do
+           kcli delete disk --novm --yes ${resource}
+        done
+    ;;
+
+    *)
+    echo "Usage: $0 [dry-run|now]"
+    ;;
+esac


### PR DESCRIPTION
# Description

Include more options:
- dry-run: to check images/disk/isos to be deleted
- now: to run clean-libvirt-pool

Now the logic takes in account more use cases to prevent images/isos/disk from being mistakenly deleted.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

- [x] I have performed my own tests
- [x] Binary has to be tested thoroughly by another colleague


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
