### PR TITLE
clean(libvirt-pool): control unbound

### DIFF
--- a/hack/clean/clean-libvirt-pool.sh
+++ b/hack/clean/clean-libvirt-pool.sh
@@ -1,64 +1,68 @@
 #!/usr/bin/env bash
 
 set -o pipefail
-set -o nounset
 set -m
 
-resourcesUsed=""
+if [ -n "${1}" ]; then
 
-# get all disk and isos in use
-getUsedResources() {
-    for vm in $(kcli list vm -o json | jq -r .[].name); do
-        # preserve ISO/iso used by existing vm's
-        resourcesUsed=$(printf "%s|${resourcesUsed}" "${vm}.ISO")
+    resourcesUsed=""
 
-        # some vm's have a boot-ID iso - depending on how they were created
-        resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep iso: | awk '{print $2}' | sed 's#\/var\/lib\/libvirt\/images\/##g')")
+    # get all disk and isos in use
+    getUsedResources() {
+        for vm in $(kcli list vm -o json | jq -r .[].name); do
+            # preserve ISO/iso used by existing vm's
+            resourcesUsed=$(printf "%s|${resourcesUsed}" "${vm}.ISO")
 
-        # preserve images used by existing vm's
-        resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep image: | awk '{print $2}' | sed 's#\/var\/lib\/libvirt\/images\/##g')")
+            # some vm's have a boot-ID iso - depending on how they were created
+            resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep iso: | awk '{print $2}' | sed 's#\/var\/lib\/libvirt\/images\/##g')")
 
-        # preserve all disks used by existing vm's
-        for disk in $(kcli show vm $vm | grep -E 'diskname:' | awk '{print $10}' | sed 's#\/var\/lib\/libvirt\/images\/##'); do
-            resourcesUsed=$(printf "%s|${resourcesUsed}" "${disk}")
+            # preserve images used by existing vm's
+            resourcesUsed=$(printf "%s|${resourcesUsed}" "$(kcli show vm ${vm} | grep image: | awk '{print $2}' | sed 's#\/var\/lib\/libvirt\/images\/##g')")
+
+            # preserve all disks used by existing vm's
+            for disk in $(kcli show vm $vm | grep -E 'diskname:' | awk '{print $10}' | sed 's#\/var\/lib\/libvirt\/images\/##'); do
+                resourcesUsed=$(printf "%s|${resourcesUsed}" "${disk}")
+            done
         done
-    done
-}
+    }
 
-# get the resources
-getUsedResources
+    # get the resources
+    getUsedResources
 
-# build a cmd that greps out the *used* resources
-# cmd has to guarantee resources in toDelete are *unused*
-# sanitize output by removing any trailing character
-# and also double || introduced by getUsedResources\
-# failing to do this will make cmd unusable and unreliable
-resourcesGrep=$(echo $resourcesUsed | sed 's/.$//' | sed 's/||/|/'g)
-cmd=$(printf "ls /var/lib/libvirt/images | grep -Ev '%s'" ${resourcesGrep})
-toDelete=$(eval $cmd)
+    # build a cmd that greps out the *used* resources
+    # cmd has to guarantee resources in toDelete are *unused*
+    # sanitize output by removing any trailing character
+    # and also double || introduced by getUsedResources\
+    # failing to do this will make cmd unusable and unreliable
+    resourcesGrep=$(echo $resourcesUsed | sed 's/.$//' | sed 's/||/|/'g)
+    cmd=$(printf "ls /var/lib/libvirt/images | grep -Ev '%s'" ${resourcesGrep})
+    toDelete=$(eval $cmd)
 
-# dry-run will prompt the images to be deleted
-# now will wipe the pool
-case "${1}" in
-    'dry-run')
-        echo "############### ${0} dry-run"
-        echo "############### resources in use - won't be deleted"
-        echo $cmd
-        echo ""
+    # dry-run will prompt the images to be deleted
+    # now will wipe the pool
+    case $1 in
+        'dry-run')
+            echo "############### ${0} dry-run"
+            echo "############### resources in use - won't be deleted"
+            echo $cmd
+            echo ""
 
-        echo "############### resources unused - will be delete"
-        for resource in $(echo $toDelete); do
-            echo $resource
-        done
-    ;;
+            echo "############### resources unused - will be delete"
+            for resource in $(echo $toDelete); do
+                echo $resource
+            done
+        ;;
 
-    'now')
-        for resource in $(echo $toDelete); do
-           kcli delete disk --novm --yes ${resource}
-        done
-    ;;
+        'now')
+            for resource in $(echo $toDelete); do
+            kcli delete disk --novm --yes ${resource}
+            done
+        ;;
 
-    *)
-    echo "Usage: $0 [dry-run|now]"
-    ;;
-esac
+        *)
+        echo "Usage: [dry-run|now]"
+        ;;
+    esac
+else
+    echo "Usage: [dry-run|now]"
+fi


### PR DESCRIPTION
# Description

- Remove `set -o nounset` so not declared variables won't make this script to fail.
- Control if $1 is present, otherwise show usage

Fixes failing on unbound $1

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Previously the failures where $1 wasn't declared:
```
$ hack/clean/clean-libvirt-pool.sh 

hack/clean/clean-libvirt-pool.sh: line 42: $1: unbound variable
```

After the changes:

- With $1 not present
```
$ hack/clean/clean-libvirt-pool.sh 
Usage: [dry-run|now]
```

- With an invalid $1
```
$ hack/clean/clean-libvirt-pool.sh whatever
Usage: [dry-run|now]
```

- With a valid $1
```
$ hack/clean/clean-libvirt-pool.sh dry-run
############### hack/clean/clean-libvirt-pool.sh dry-run
############### resources in use - won't be deleted
ls /var/lib/libvirt/images | grep -Ev 'test_0.img|CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2|test.ISO|ansible-vm-target_0.img|CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2|ansible-vm-target.ISO|ansible-ci-target2_0.img|CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2|ansible-ci-target2.ISO|CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2|ansible-ci-target-2.ISO|ansible-ci-target_0.img|CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2|ansible-ci-target.ISO'

############### resources unused - will be delete
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
