### PR TITLE
Revert "build(deps): bump actions/setup-python from 3 to 4"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v3
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
Reverts rh-ecosystem-edge/ztp-pipeline-relocatable#391 as per https://github.com/actions/setup-python/issues/421