### PR TITLE
fix(Makefile): reverse clean order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,13 +183,14 @@ bootstrap-ci:
 	./bootstrap.sh $(RELEASE)
 
 clean:
+	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0; \
 	oc delete managedcluster $(EDGE_NAME); \
 	oc delete ns $(EDGE_NAME); \
-	oc rollout restart -n openshift-machine-api deployment/metal3; \
-	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0
+	oc rollout restart -n openshift-machine-api deployment/metal3;
 
 clean-ci:
 	# From: https://github.com/stolostron/deploy/blob/master/hack/cleanup-managed-cluster.sh
+	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0; \
 	list=$$(tkn pr ls -n edgecluster-deployer |grep -i running | cut -d' ' -f1); \
 	for i in ${list}; do tkn pr cancel $${i} -n edgecluster-deployer; done; \
 	oc delete --ignore-not-found=true managedcluster $(EDGE_NAME); \
@@ -198,5 +199,4 @@ clean-ci:
 	list=$$(oc get secret -n $(EDGE_NAME) --no-headers |grep bmc|awk '{print $$1}'); \
 	for i in $${list}; do oc patch -n $(EDGE_NAME) secret $${i} --type json -p '[ { "op": "remove", "path": "/metadata/finalizers" } ]'; done; \
 	oc delete --ignore-not-found=true ns $(EDGE_NAME); \
-	oc rollout restart -n openshift-machine-api deployment/metal3; \
-	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0
+	oc rollout restart -n openshift-machine-api deployment/metal3;


### PR DESCRIPTION
# Description

Sometimes during a make clean, the cleaning process is stuck forever.

This is because deleting objects in Kubernetes/OCP follows a cascade pattern:
- We try to delete the namespace
- The namespace tries to finalize all the resources under it
- The BaremetalHost in the namespace calls their own finalizer at metal3 API, and the API starts the deprovisioning
- This deprovisioning under certain circunstamces never ends

By deleting first the vm's:
- The deprovisioning procedure is skipped (we don´t need it as the vm does not exist, anyway)
- Rest of the cleaning is performed as usual

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

- [x] Tested multiple times cleaning environments 


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
