### PR TITLE
ci(ui): fix first if

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -5,12 +5,11 @@ on:
     paths:
       - 'ui/**'
     types: [labeled,synchronize]
-  pull_request_review:
-    types: [submitted, edited]
+  workflow_dispatch:
 
 jobs:
   build:
-    if: (!contains(github.event.label.name, 'skip-ci-ui') || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ci-ui')
+    if: (!contains(github.event.label.name, 'skip-ci-ui') && !contains(github.event.pull_request.labels.*.name, 'skip-ci-ui')) || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ci-ui')
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max-old-space-size=8192'


### PR DESCRIPTION
# Description

An attempt to fix the triggering of the ui workflow for every pull_request, and also fix the first if which is faulty and GHA constantly complains about:
```
[Invalid workflow file: .github/workflows/ui.yml#L17](https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/actions/runs/2503700143/workflow)
The workflow is not valid. .github/workflows/ui.yml (Line: 17, Col: 9): Unexpected end of expression: ')'. Located at position 160 within expression: (!contains(github.event.label.name, 'skip-ci-ui') || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ci-ui')
```

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
