### PR TITLE
MGMT-10892 Safe navigation to the /wizard/persist page for no change

### DIFF
--- a/ui/frontend/src/components/K8SStateContext.tsx
+++ b/ui/frontend/src/components/K8SStateContext.tsx
@@ -136,7 +136,7 @@ export const K8SStateContextProvider: React.FC<{
   const fieldValues = React.useRef<K8SStateContextDataFields>(_fv);
   fieldValues.current = _fv;
 
-  const [snapshot, setSnapshot] = React.useState<K8SStateContextDataFields>();
+  const [snapshot, setSnapshot] = React.useState<K8SStateContextDataFields>(_fv);
   const setClean = React.useCallback(() => {
     setSnapshot(fieldValues.current);
   }, [fieldValues]);

--- a/ui/frontend/src/components/PersistPage/PersistPageBottom.tsx
+++ b/ui/frontend/src/components/PersistPage/PersistPageBottom.tsx
@@ -39,7 +39,11 @@ export const PersistPageBottom: React.FC = () => {
         navigateToNewDomain(state.domain, '/wizard/final'),
       );
     } else {
-      console.warn('No change to persist on the PersistPage');
+      console.warn(
+        'No change to persist on the PersistPage. The reconcilliation might be still running if the user got here after page refresh.',
+      );
+      // TODO: Find out what's going on and resume the progress bar for the user
+      navigateToNewDomain(state.domain, '/wizard/welcome');
     }
   }, [retry, setError, progress.setProgress, state]);
 

--- a/ui/frontend/src/components/PersistPage/persist.ts
+++ b/ui/frontend/src/components/PersistPage/persist.ts
@@ -163,7 +163,14 @@ export const navigateToNewDomain = async (domain: string, contextPath: string) =
   // We can not check livenessProbe on the new domain due to CORS
   // We can not use pod serving old domain either since it will be terminated and the route changed
   // So just wait...
-  const ztpfwUrl = `https://${ZTPFW_UI_ROUTE_PREFIX}.apps.${domain}${contextPath}`;
+  let ztpfwUrl: string;
+  if (!domain) {
+    // fallback
+    ztpfwUrl = `${window.location.origin}${contextPath}`;
+  } else {
+    ztpfwUrl = `https://${ZTPFW_UI_ROUTE_PREFIX}.apps.${domain}${contextPath}`;
+  }
+
   console.info('Changes are persisted, about to navigate to the new domain: ', ztpfwUrl);
   // We should go with following:
   window.location.replace(ztpfwUrl);


### PR DESCRIPTION
If the user navigates to the /persist page either directly without providing
data first or just by hitting F5 during persistence, the actual persist() routine
is skipped and the user is navigated to the /welcome screen instead.

This fix avoids blind saving of default data.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
