### PR TITLE
Revert "fix(Makefile): reverse clean order"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,14 +183,13 @@ bootstrap-ci:
 	./bootstrap.sh $(RELEASE)
 
 clean:
-	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0; \
 	oc delete managedcluster $(EDGE_NAME); \
 	oc delete ns $(EDGE_NAME); \
-	oc rollout restart -n openshift-machine-api deployment/metal3;
+	oc rollout restart -n openshift-machine-api deployment/metal3; \
+	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0
 
 clean-ci:
 	# From: https://github.com/stolostron/deploy/blob/master/hack/cleanup-managed-cluster.sh
-	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0; \
 	list=$$(tkn pr ls -n edgecluster-deployer |grep -i running | cut -d' ' -f1); \
 	for i in ${list}; do tkn pr cancel $${i} -n edgecluster-deployer; done; \
 	list=$$($ oc get bmh -n $(EDGE_NAME) --no-headers|awk '{print $$1}'); \
@@ -199,4 +198,5 @@ clean-ci:
 	for i in $${list}; do oc patch -n $(EDGE_NAME) secret $${i} --type json -p '[ { "op": "remove", "path": "/metadata/finalizers" } ]'; done; \
 	oc delete --ignore-not-found=true managedcluster $(EDGE_NAME); \
 	oc delete --ignore-not-found=true ns $(EDGE_NAME); \
-	oc rollout restart -n openshift-machine-api deployment/metal3;
+	oc rollout restart -n openshift-machine-api deployment/metal3; \
+	kcli delete vm -y $(EDGE_NAME)-m0 $(EDGE_NAME)-m1 $(EDGE_NAME)-m2 $(EDGE_NAME)-w0


### PR DESCRIPTION
Reverts rh-ecosystem-edge/ztp-pipeline-relocatable#410

This PR seems to be breaking the clean-up process quite a bit.

@fbac and I chatted a bit about it and he mentioned that one of the motivations behind the original PR was to avoid doing the cleanup. That said, cleanup should not happen since we have `automaticCleaning` set to false. Removing the VMs from metaal3 is causing the finalizers to constantly get stuck, which makes the cleanup process slow and error prone.

So, we either go this way or we start removing the finalizers as a hack. 