### PR TITLE
ci(nfs): do wipe instead of full removal

### DIFF
--- a/hack/deploy-hub-local/lab-nfs.sh
+++ b/hack/deploy-hub-local/lab-nfs.sh
@@ -3,7 +3,15 @@ set -euo pipefail
 
 #clean before
 > /etc/exports
-rm -fr /pv0*
+
+# Generate list of PV's
+PVS=$(seq 1 10)
+
+# Remove always inside 'pv' folder to avoid root disk nuking
+for i in ${PVS}; do
+	export PV=$(printf "%03d" ${i})
+	rm -fr /pv$PV/*
+done
 
 # install the nfs
 export KUBECONFIG=/root/.kcli/clusters/test-ci/auth/kubeconfig
@@ -11,7 +19,7 @@ export PRIMARY_IP=192.168.150.1
 dnf -y install nfs-utils
 systemctl enable --now nfs-server
 export MODE="ReadWriteOnce"
-for i in $(seq 1 10); do
+for i in ${PVS}; do
 	export PV=pv$(printf "%03d" ${i})
 	mkdir /${PV} ||true
 	echo "/${PV} *(rw,no_root_squash)" >>/etc/exports

--- a/hack/deploy-hub-local/lab-nfs.sh
+++ b/hack/deploy-hub-local/lab-nfs.sh
@@ -10,8 +10,10 @@ export PRIMARY_IP=192.168.150.1
 dnf -y install nfs-utils
 systemctl enable --now nfs-server
 export MODE="ReadWriteOnce"
+PVS=$(seq 1 10)
 for i in ${PVS}; do
 	export PV=pv$(printf "%03d" ${i})
+	rm -fr /pv$PV/*
 	mkdir /${PV} ||true
 	echo "/${PV} *(rw,no_root_squash)" >>/etc/exports
 	chcon -t svirt_sandbox_file_t /${PV}

--- a/hack/deploy-hub-local/lab-nfs.sh
+++ b/hack/deploy-hub-local/lab-nfs.sh
@@ -4,15 +4,6 @@ set -euo pipefail
 #clean before
 > /etc/exports
 
-# Generate list of PV's
-PVS=$(seq 1 10)
-
-# Remove always inside 'pv' folder to avoid root disk nuking
-for i in ${PVS}; do
-	export PV=$(printf "%03d" ${i})
-	rm -fr /pv$PV/*
-done
-
 # install the nfs
 export KUBECONFIG=/root/.kcli/clusters/test-ci/auth/kubeconfig
 export PRIMARY_IP=192.168.150.1


### PR DESCRIPTION
# Description

NFS setup script removes the folder, this makes it harder to do custom configurations that depends on symlinks, etc.


This PR makes the cleaning to be less destructive, just removing the contents but not the folder (or symlink)
