### PR TITLE
fix: Make quay.io use pull secret only

### DIFF
--- a/shared-utils/common.sh
+++ b/shared-utils/common.sh
@@ -9,7 +9,7 @@ function registry_login() {
     export STORAGE_DRIVER=vfs
     sed -i '/^mountopt =.*/d' /etc/containers/storage.conf
 
-    if [[ ${CUSTOM_REGISTRY} == "true" ]]; then
+    if [[ ${CUSTOM_REGISTRY} == "true" ]] || [[ ${1} == "quay.io" ]]; then
         ${PODMAN_LOGIN_CMD} ${1} --authfile=${PULL_SECRET}
     else
         ${PODMAN_LOGIN_CMD} ${1} -u ${REG_US} -p ${REG_PASS} --authfile=${PULL_SECRET}


### PR DESCRIPTION
If the remote registry is quay, we don't have user/pass as we only use the pull secret, avoid using them.

Fixes #452 

