### PR TITLE
MGMT-10030 patch fixing configmap error on image service

### DIFF
--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -89,7 +89,7 @@ function trust_internal_registry() {
         echo ">> Cert: ${PATH_CA_CERT}"
     else
         export CA_CERT_DATA=$(openssl s_client -connect ${LOCAL_REG} -showcerts </dev/null | openssl x509 | base64 | tr -d '\n')
-        MYREGISTRY=${LOCAL_REG}
+        MYREGISTRY=${REGISTRY}
     fi
 
     ## Update trusted CA from Helper


### PR DESCRIPTION
# Description

key name error fix on the `ConfigMap` creation
effects  only 3rd party registry
 
`error: "flavio4.alklabs.local:5000" is not a valid key name for a ConfigMap: a valid config key`


Fixes # (issue)

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

- Tested locally 