### PR TITLE
fix the bug for metallb operator

### DIFF
--- a/deploy-metallb/deploy.sh
+++ b/deploy-metallb/deploy.sh
@@ -297,6 +297,7 @@ if ! ./verify.sh; then
         # "Patch bz https://bugzilla.redhat.com/show_bug.cgi?id=2106840"
         echo ">> Patching the MetalLB operator"
         oc --kubeconfig=${EDGE_KUBECONFIG} adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-nmstate:nmstate-operator
+        oc --kubeconfig=${EDGE_KUBECONFIG} adm policy add-cluster-role-to-user cluster-admin nmstate-operator
 
         echo ">>>> Deploying NMState Operand for ${edgecluster}"
         ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP} "oc apply -f manifests/04-NMS-Operand.yaml"

--- a/deploy-metallb/deploy.sh
+++ b/deploy-metallb/deploy.sh
@@ -279,6 +279,10 @@ if ! ./verify.sh; then
         copy_files "${EDGE_KUBECONFIG}" "${EDGE_NODE_IP}" "./.kube/config"
         echo
 
+        # "Patch bz https://bugzilla.redhat.com/show_bug.cgi?id=2106840"
+        echo ">> Patching the MetalLB operator"
+        ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP}  "oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-nmstate:nmstate-operator"
+
         echo ">> Deploying NMState and MetalLB for ${edgecluster}"
         ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP} "oc apply -f manifests/01-NMS-Namespace.yaml -f manifests/02-NMS-OperatorGroup.yaml -f manifests/01-MLB-Namespace.yaml -f manifests/02-MLB-OperatorGroup.yaml"
         sleep 2
@@ -294,9 +298,7 @@ if ! ./verify.sh; then
         verify_remote_resource ${edgecluster} "default" "crd" "metallbs.metallb.io" "."
         echo
 
-        # "Patch bz https://bugzilla.redhat.com/show_bug.cgi?id=2106840"
-        echo ">> Patching the MetalLB operator"
-        oc --kubeconfig=${EDGE_KUBECONFIG} adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-nmstate:nmstate-operator
+
 
         echo ">>>> Deploying NMState Operand for ${edgecluster}"
         ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP} "oc apply -f manifests/04-NMS-Operand.yaml"

--- a/deploy-metallb/deploy.sh
+++ b/deploy-metallb/deploy.sh
@@ -297,7 +297,6 @@ if ! ./verify.sh; then
         # "Patch bz https://bugzilla.redhat.com/show_bug.cgi?id=2106840"
         echo ">> Patching the MetalLB operator"
         oc --kubeconfig=${EDGE_KUBECONFIG} adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-nmstate:nmstate-operator
-        oc --kubeconfig=${EDGE_KUBECONFIG} adm policy add-cluster-role-to-user cluster-admin nmstate-operator
 
         echo ">>>> Deploying NMState Operand for ${edgecluster}"
         ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP} "oc apply -f manifests/04-NMS-Operand.yaml"

--- a/deploy-metallb/deploy.sh
+++ b/deploy-metallb/deploy.sh
@@ -298,8 +298,6 @@ if ! ./verify.sh; then
         verify_remote_resource ${edgecluster} "default" "crd" "metallbs.metallb.io" "."
         echo
 
-
-
         echo ">>>> Deploying NMState Operand for ${edgecluster}"
         ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP} "oc apply -f manifests/04-NMS-Operand.yaml"
         sleep 2

--- a/deploy-metallb/deploy.sh
+++ b/deploy-metallb/deploy.sh
@@ -294,6 +294,10 @@ if ! ./verify.sh; then
         verify_remote_resource ${edgecluster} "default" "crd" "metallbs.metallb.io" "."
         echo
 
+        # "Patch bz https://bugzilla.redhat.com/show_bug.cgi?id=2106840"
+        echo ">> Patching the MetalLB operator"
+        oc --kubeconfig=${EDGE_KUBECONFIG} adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:openshift-nmstate:nmstate-operator
+
         echo ">>>> Deploying NMState Operand for ${edgecluster}"
         ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${EDGE_NODE_IP} "oc apply -f manifests/04-NMS-Operand.yaml"
         sleep 2


### PR DESCRIPTION
Signed-off-by: Alberto Morgante Medina <alknopfler@users.noreply.github.com>

# Description

Fix the issue with the nmstate operator:
````
account:openshift-nmstate:nmstate-operator" cannot list resource "nodes" in API group "" at the cluster scope
E0713 15:43:47.466609       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:250: Failed to watch *v1.Node: failed to list *v1.Node: nodes is forbidden: User "system:serviceaccount:openshift-nmstate:nmstate-operator" cannot list resource "nodes" in API group "" at the cluster scope
````

Fixes # reported the bug here: https://bugzilla.redhat.com/show_bug.cgi?id=2106840

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- @achuzhoy tested on his environment working fine after apply the command to fix the issue doing this workarround
 [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
