### PR TITLE
Fix: Makefile issue with release tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ ODF_VERSION ?= 4.10
 
 
 
-ifeq ($(BRANCH),)
-BRANCH := $(RELEASE)
+ifneq ($(TAG),)
+BRANCH := $(TAG)
 endif
 
 .PHONY: all-images pipe-image pipe-image-ci ui-image ui-image-ci all-hub-sno all-hub-compact all-edgecluster-sno all-edgecluster-compact build-pipe-image build-ui-image push-pipe-image push-ui-image doc build-hub-sno build-hub-compact wait-for-hub-sno deploy-pipe-hub-sno deploy-pipe-hub-compact build-edgecluster-sno build-edgecluster-compact build-edgecluster-sno-2nics build-edgecluster-compact-2nics deploy-pipe-edgecluster-sno deploy-pipe-edgecluster-compact bootstrap bootstrap-ci deploy-pipe-hub-mce-sno deploy-pipe-hub-mce-compact deploy-pipe-hub-ci deploy-pipe-hub-ci deploy-pipe-edgecluster-sno-ci deploy-pipe-edgecluster-compact-ci all-hub-sno-ci all-hub-compact-ci all-edgecluster-sno-ci all-edgecluster-compact-ci all-images-ci


### PR DESCRIPTION
Signed-off-by: Alberto Morgante Medina <alknopfler@users.noreply.github.com>

# Description

The problem is that with existing code, we're not able to launch a 1.10.3 tag using RELEASE=1.10.3 make deploy... command:
```
ifneq ($(BRANCH),)
BRANCH := $(RELEASE)
endif
```
always will be launched from a branch and release never will be selected. 
To fixed we've created a TAG variable in order to:
- TAG=1.10.3 make deploy...  -> to deploy an specific image from a tag (previous built)
- make deploy... -> Inside a branch in your repo to deploy an specific branch image (previous built)


## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

![image](https://user-images.githubusercontent.com/9356454/179217985-64388cfa-9bf6-4ef1-8a6e-411843c0a96e.png)


**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
