### PR TITLE
NO-ISSUE: Add retries when waiting for worker agent 

### DIFF
--- a/deploy-worker/render_worker.sh
+++ b/deploy-worker/render_worker.sh
@@ -193,13 +193,17 @@ index=0
 
 for EDGE in ${ALLEDGECLUSTERS}; do
     create_worker_definitions ${EDGE} ${index}
-    WORKER_AGENT=$(oc --kubeconfig=${KUBECONFIG_HUB} get agent -n ${EDGE} --no-headers | grep worker | awk '{print $1}')
-    if [ "x${WORKER_AGENT}" == "x" ]; then
-        echo "Worker agent is empty for ${EDGE}, sleeping a bit more... 120 secs"
-        sleep 120
+    for a in {1..10}; do
         WORKER_AGENT=$(oc --kubeconfig=${KUBECONFIG_HUB} get agent -n ${EDGE} --no-headers | grep worker | awk '{print $1}')
+        if [ "x${WORKER_AGENT}" == "x" ]; then
+            echo "Worker agent is empty for ${EDGE}, sleeping a bit more... 60 secs"
+            sleep 60
+            continue
+        fi
+
         echo "Now worker agent is ${WORKER_AGENT}"
-    fi
+        break
+    done
     check_resource "agent" "${WORKER_AGENT}" "Installed" "${EDGE}" "${KUBECONFIG_HUB}"
     index=$((index + 1))
 done


### PR DESCRIPTION
On BM agents can take more than 120s to come up. This change will help us wait in loops of 1 minute for, at most, 10 mins

Backport for #480 

Signed-off-by: Flavio Percoco <flavio@redhat.com>
Co-authored-by: Flavio Percoco <flavio@redhat.com>
(cherry picked from commit bf105c9f40b65e794894d90782ffcb7503ae445f)

