### PR TITLE
Revert "Require CI UI build to pass"

### DIFF
--- a/.github/workflows/testing-pr-compact.yml
+++ b/.github/workflows/testing-pr-compact.yml
@@ -51,7 +51,7 @@ jobs:
           RELEASE=${RELEASE} make pipe-image-ci
 
       - name: Build and Push UI Image
-        ## continue-on-error: true  # Workaround until the generation is fixed
+        continue-on-error: true  # Workaround until the generation is fixed
         id: build-ui
         run: |
           cd ${{ github.workspace }}

--- a/ui/README.md
+++ b/ui/README.md
@@ -42,4 +42,3 @@ For productoin build:
 yarn install
 yarn build
 ```
-


### PR DESCRIPTION
Reverts rh-ecosystem-edge/ztp-pipeline-relocatable#483