### PR TITLE
adding post verification on downloaded files

### DIFF
--- a/deploy-httpd-server/deploy.sh
+++ b/deploy-httpd-server/deploy.sh
@@ -29,13 +29,19 @@ if ./verify.sh; then
 
     RHCOS_ISO="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-${OC_OCP_VERSION_MIN}/rhcos-live.x86_64.iso"
     RHCOS_ROOTFS="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-${OC_OCP_VERSION_MIN}/rhcos-live-rootfs.x86_64.img"
+    RHCOS_SHA="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-${OC_OCP_VERSION_MIN}/sha256sum.txt"
     BASE_ISO=$(basename $RHCOS_ISO)
     BASE_ROOTFS=$(basename $RHCOS_ROOTFS)
+    BASE_SHA=$(basename $RHCOS_SHA)
     podname=$(oc get pod -n ${HTTPD_NS} | grep httpd | awk '{print $1}')
 
     oc exec -n ${HTTPD_NS} ${podname} -- mkdir -p /var/www/html/"${OC_OCP_VERSION_MIN}"
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk ${RHCOS_ISO} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_ISO}"
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk ${RHCOS_ROOTFS} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_ROOTFS}"
+
+    echo "INFO: verifing Downloaded files"
+    oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk  ${RHCOS_SHA} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_SHA"§
+    oc exec -n ${HTTPD_NS} ${podname} -- sha256sum --check sha256sum.txt  --ignore-missing  
 else
     echo ">>>> This step is not neccesary, everything looks ready"
 fi

--- a/deploy-httpd-server/deploy.sh
+++ b/deploy-httpd-server/deploy.sh
@@ -39,7 +39,7 @@ if ./verify.sh; then
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk ${RHCOS_ISO} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_ISO}"
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk ${RHCOS_ROOTFS} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_ROOTFS}"
 
-    echo "INFO: verifing Downloaded files"
+    echo "INFO: verifying Downloaded files"
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk  ${RHCOS_SHA} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_SHA"§
     oc exec -n ${HTTPD_NS} ${podname} -- sha256sum --check sha256sum.txt  --ignore-missing  
 else

--- a/deploy-httpd-server/deploy.sh
+++ b/deploy-httpd-server/deploy.sh
@@ -40,8 +40,8 @@ if ./verify.sh; then
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk ${RHCOS_ROOTFS} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_ROOTFS}"
 
     echo "INFO: verifying Downloaded files"
-    oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk  ${RHCOS_SHA} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_SHA"§
-    oc exec -n ${HTTPD_NS} ${podname} -- sha256sum --check sha256sum.txt  --ignore-missing  
+    oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk  ${RHCOS_SHA} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_SHA}"§
+    oc exec -n ${HTTPD_NS} ${podname} -- sha256sum --check "${BASE_SHA}" --ignore-missing  
 else
     echo ">>>> This step is not neccesary, everything looks ready"
 fi

--- a/deploy-httpd-server/deploy.sh
+++ b/deploy-httpd-server/deploy.sh
@@ -40,7 +40,7 @@ if ./verify.sh; then
     oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk ${RHCOS_ROOTFS} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_ROOTFS}"
 
     echo "INFO: verifying Downloaded files"
-    oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk  ${RHCOS_SHA} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_SHA}"§
+    oc exec -n ${HTTPD_NS} ${podname} -- curl -Lk  ${RHCOS_SHA} -o /var/www/html/"${OC_OCP_VERSION_MIN}"/"${BASE_SHA}"
     oc exec -n ${HTTPD_NS} ${podname} -- sha256sum --check "${BASE_SHA}" --ignore-missing  
 else
     echo ">>>> This step is not neccesary, everything looks ready"


### PR DESCRIPTION
Signed-off-by: eifrach <eifrach@redhat.com>

# Description

on some deployments, the HTTP pods reaches the memory limit and fail top download the files
this will add a check post deployment to verify the integrity of the files 

example of a deployment with an error 137
```console
$ sha256sum --check sha256sum.txt --ignore-missing
rhcos-live-rootfs.x86_64.img: OK
rhcos-live.x86_64.iso: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
```

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
