### PR TITLE
NO-ISSUE: Use a dedicated build dir per pipeline/task

### DIFF
--- a/deploy-disconnected-registry/ocp-sync.sh
+++ b/deploy-disconnected-registry/ocp-sync.sh
@@ -18,7 +18,7 @@ function extract_kubeconfig() {
     ## Extract the Edge-cluster kubeconfig and put it on the shared folder
     export EDGE_KUBECONFIG="${OUTPUTDIR}/kubeconfig-${1}"
     echo "Exporting EDGE_KUBECONFIG: ${EDGE_KUBECONFIG}"
-    oc --kubeconfig=${KUBECONFIG_HUB} get secret -n $edgecluster $edgecluster-admin-kubeconfig -o jsonpath=‘{.data.kubeconfig}’ | base64 -d >${EDGE_KUBECONFIG}
+    oc --kubeconfig=${KUBECONFIG_HUB} extract -n $edgecluster secret/$edgecluster-admin-kubeconfig --to - >${EDGE_KUBECONFIG}
 }
 
 function mirror_ocp() {

--- a/deploy-disconnected-registry/olm-sync.sh
+++ b/deploy-disconnected-registry/olm-sync.sh
@@ -12,7 +12,7 @@ function extract_kubeconfig() {
     ## Extract the Edge-cluster kubeconfig and put it on the shared folder
     export EDGE_KUBECONFIG="${OUTPUTDIR}/kubeconfig-${1}"
     echo "Exporting EDGE_KUBECONFIG: ${EDGE_KUBECONFIG}"
-    oc --kubeconfig=${KUBECONFIG_HUB} get secret -n $edgecluster $edgecluster-admin-kubeconfig -o jsonpath='{.data.kubeconfig}' | base64 -d >${EDGE_KUBECONFIG}
+    oc --kubeconfig=${KUBECONFIG_HUB} extract -n $edgecluster secret/$edgecluster-admin-kubeconfig --to - >${EDGE_KUBECONFIG}
 }
 
 function prepare_env() {

--- a/pipelines/resources/common/common-pre-flight-edgeclusters.yaml
+++ b/pipelines/resources/common/common-pre-flight-edgeclusters.yaml
@@ -15,6 +15,9 @@ spec:
     - name: edgeclusters-config
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: kubeconfig
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: KUBECONFIG
         value: $(params.kubeconfig)
       - name: EDGECLUSTERS_CONFIG
@@ -40,8 +45,9 @@ spec:
       script: |
         #!/usr/bin/bash
         if [[ "${MOCK}" == 'false' ]]; then
+          mkdir -p ${WORKDIR}
+          mkdir -p ${OUTPUTDIR}
           cp -r /opt/ztp/* ${WORKDIR}/
-          mkdir -p ${WORKDIR}/build
           cd ${WORKDIR}/${SHARED_DIR}
           ./verify_preflight.sh
           ./verify_preflight-edgeclusters.sh

--- a/pipelines/resources/common/common-pre-flight-edgeclusters.yaml
+++ b/pipelines/resources/common/common-pre-flight-edgeclusters.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: kubeconfig
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: KUBECONFIG
         value: $(params.kubeconfig)
       - name: EDGECLUSTERS_CONFIG

--- a/pipelines/resources/common/common-pre-flight.yaml
+++ b/pipelines/resources/common/common-pre-flight.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: kubeconfig
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: KUBECONFIG
         value: $(params.kubeconfig)
       - name: EDGECLUSTERS_CONFIG

--- a/pipelines/resources/common/common-pre-flight.yaml
+++ b/pipelines/resources/common/common-pre-flight.yaml
@@ -15,6 +15,9 @@ spec:
     - name: edgeclusters-config
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: kubeconfig
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: KUBECONFIG
         value: $(params.kubeconfig)
       - name: EDGECLUSTERS_CONFIG
@@ -41,8 +46,9 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
+          mkdir -p ${WORKDIR}
+          mkdir -p ${OUTPUTDIR}
           cp -r /opt/ztp/* ${WORKDIR}/
-          mkdir -p ${WORKDIR}/build
           cd ${WORKDIR}/${SHARED_DIR}
           ./verify_preflight.sh
         else

--- a/pipelines/resources/contrib/contrib-gpu-operator.yaml
+++ b/pipelines/resources/contrib/contrib-gpu-operator.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: pipeline-name
+      type: string
+      default: $(context.taskRun.name)
     - name: kubeconfig
       type: string
       default: ""
@@ -24,7 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/contrib/contrib-template.yaml
+++ b/pipelines/resources/contrib/contrib-template.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -24,7 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -32,6 +32,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     workspaces:
       - name: ztp
         workspace: ztp
@@ -49,6 +51,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - pre-flight
     workspaces:
@@ -68,6 +72,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -87,6 +93,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:
@@ -107,6 +115,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-metallb
     workspaces:
@@ -126,6 +136,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-lvmo
     workspaces:
@@ -145,6 +157,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-lvmo
     workspaces:
@@ -164,6 +178,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-odf
     workspaces:
@@ -183,6 +199,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-disconnected-registry
     workspaces:
@@ -202,6 +220,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-disconnected-registry
     workspaces:
@@ -221,6 +241,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - mirror-ocp-images
       - mirror-olm-images
@@ -241,6 +263,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-disconnected-registry-ps
     workspaces:
@@ -260,6 +284,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-icsp-edgeclusters-post
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -32,6 +32,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     workspaces:
       - name: ztp
         workspace: ztp
@@ -49,6 +51,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - pre-flight
     workspaces:
@@ -68,6 +72,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -87,6 +93,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:
@@ -106,6 +114,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-metallb
     workspaces:
@@ -125,6 +135,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-metallb
     workspaces:
@@ -143,6 +155,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-workers
     workspaces:
@@ -162,6 +176,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-lso
     workspaces:
@@ -181,6 +197,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-odf
     workspaces:
@@ -200,6 +218,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-disconnected-registry
     workspaces:
@@ -219,6 +239,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-disconnected-registry
     workspaces:
@@ -238,6 +260,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - mirror-ocp-images
       - mirror-olm-images
@@ -258,6 +282,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-disconnected-registry-ps
     workspaces:
@@ -278,6 +304,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - deploy-icsp-edgeclusters-post
     workspaces:
@@ -297,6 +325,8 @@ spec:
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
     runAfter:
       - gpu-operator
     workspaces:

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ocp.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ocp.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ocp.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ocp.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-olm.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-olm.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-olm.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-olm.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ps.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ps.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ps.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters-ps.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters.yaml
@@ -17,6 +17,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,6 +30,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-disconnected-registry-edgeclusters.yaml
@@ -19,7 +19,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -29,9 +29,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-post.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-post.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-post.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-post.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-lso.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-lso.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-lso.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-lso.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-lvmo.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-lvmo.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-lvmo.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-lvmo.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-odf.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-odf.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-odf.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-odf.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-ui.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-ui.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-ui.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-ui.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-workers.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-workers.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-workers.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-workers.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-detach-cluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-detach-cluster.yaml
@@ -17,7 +17,7 @@ spec:
       default: ""
     - name: pipeline-name
       type: string
-      default: "all"
+      default: $(context.taskRun.name)
     - name: edgeclusters-config
       type: string
       default: ""
@@ -27,9 +27,9 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/$(params.pipeline-name)"
       - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/edgeclusters/edgecluster-detach-cluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-detach-cluster.yaml
@@ -15,6 +15,9 @@ spec:
     - name: kubeconfig
       type: string
       default: ""
+    - name: pipeline-name
+      type: string
+      default: "all"
     - name: edgeclusters-config
       type: string
       default: ""
@@ -25,6 +28,8 @@ spec:
     env:
       - name: WORKDIR
         value: "/workspace/ztp"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/$(context.taskRun.name)"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-deploy-acm.yaml
+++ b/pipelines/resources/hub/hub-deploy-acm.yaml
@@ -24,7 +24,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp/"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-deploy-disconnected-registry.yaml
+++ b/pipelines/resources/hub/hub-deploy-disconnected-registry.yaml
@@ -27,7 +27,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-deploy-httpd-server.yaml
+++ b/pipelines/resources/hub/hub-deploy-httpd-server.yaml
@@ -24,7 +24,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-deploy-hub-config.yaml
+++ b/pipelines/resources/hub/hub-deploy-hub-config.yaml
@@ -24,7 +24,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-deploy-icsp.yaml
+++ b/pipelines/resources/hub/hub-deploy-icsp.yaml
@@ -24,7 +24,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-deploy-mce.yaml
+++ b/pipelines/resources/hub/hub-deploy-mce.yaml
@@ -24,7 +24,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/pipelines/resources/hub/hub-save-config.yaml
+++ b/pipelines/resources/hub/hub-save-config.yaml
@@ -24,7 +24,7 @@ spec:
   stepTemplate:
     env:
       - name: WORKDIR
-        value: "/workspace/ztp"
+        value: "/workspace/ztp/ztp"
       - name: EDGECLUSTERS_CONFIG
         value: $(params.edgeclusters-config)
       - name: KUBECONFIG

--- a/shared-utils/common.sh
+++ b/shared-utils/common.sh
@@ -353,9 +353,7 @@ if [ -z ${KUBECONFIG+x} ]; then
 fi
 
 if [[ ! -f ${KUBECONFIG} && -f "/run/secrets/kubernetes.io/serviceaccount/token" ]]; then
-    if [ -z "${KUBECONFIG+x}" ]; then
-        export KUBECONFIG="${OUTPUTDIR}/kubeconfig"
-    fi
+    export KUBECONFIG="${OUTPUTDIR}/kubeconfig-hub"
     echo "Kubeconfig file doesn't exist: creating one from token"
     oc config set-credentials edgeclusters-deployer --token=$(cat /run/secrets/kubernetes.io/serviceaccount/token)
 elif [[ ! -f ${KUBECONFIG} ]]; then


### PR DESCRIPTION
# Description

It is currently not possible to run multiple deployments in parallel because ZTPFW re-uses the same `build` dir for all pipelines. This PR creates a dedicated `OUTPUTDIR` using the `pipeline-name/task-name` of the specific run. 

`all` is used in case of a no pipeline (task ran in isolation)

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

![image](https://user-images.githubusercontent.com/13816/182849718-12ffd44e-1794-4f83-a189-203892e413d6.png)

Example of the build dir:

![image](https://user-images.githubusercontent.com/13816/182849844-b8b51831-5e17-4b97-b79d-26c056ac5f24.png)

![image](https://user-images.githubusercontent.com/13816/182850598-ab96feb2-0d10-4b85-aac2-418bbd526660.png)


**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
