### PR TITLE
We don't need to create a new RSA key if one existed.

### DIFF
--- a/shared-utils/common.sh
+++ b/shared-utils/common.sh
@@ -173,8 +173,18 @@ function generate_rsa_edgecluster() {
     export RSA_PUB_FILE="${EDGE_SAFE_FOLDER}/${edgecluster}-rsa.key.pub"
 
     if [[ ! -f ${RSA_KEY_FILE} ]]; then
-        echo "RSA Key for Edge-cluster Cluster ${edgecluster} Not Found, creating one in ${EDGE_SAFE_FOLDER} folder"
-        ssh-keygen -b 4096 -t rsa -f ${RSA_KEY_FILE} -q -N ""
+        echo "RSA Key for Edge-cluster Cluster ${edgecluster} Not Found. Will create one in ${EDGE_SAFE_FOLDER} folder"
+
+        oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} secret/${cluster}-keypair >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            echo "Extracting the RSA key from a secret"
+            oc --kubeconfig=${KUBECONFIG_HUB} extract -n ${cluster} secret/${cluster}-keypair --keys id_rsa.key --to - 2>/dev/null >${RSA_KEY_FILE}
+            chmod 600 ${RSA_KEY_FILE}
+            oc --kubeconfig=${KUBECONFIG_HUB} extract -n ${cluster} secret/${cluster}-keypair --keys id_rsa.pub --to - 2>/dev/null >${RSA_PUB_FILE}
+        else
+            echo "Generating a new RSA key"
+            ssh-keygen -b 4096 -t rsa -f ${RSA_KEY_FILE} -q -N ""
+        fi
         echo "Checking RSA Keys generated..."
         if [[ ! -f ${RSA_KEY_FILE} || ! -f ${RSA_PUB_FILE} ]]; then
             echo "RSA Private or Public key not found"


### PR DESCRIPTION
When we re-run the pipeline after the edgecluster was already
deployed, the key needs to be extracted from a secret instead
of creating a new one.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
