### PR TITLE
NO_ISSUE: Let PVC use the default storageclass

### DIFF
--- a/pipelines/resources/common/pvc-template.yaml
+++ b/pipelines/resources/common/pvc-template.yaml
@@ -4,7 +4,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: ztp-pvc
 spec:
-  storageClassName: odf-lvm-vg1
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
# Description

There should be a default storageclass in the cluster when this manifest is applied. No need to hard-code the storageclass.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

@achuzhoy tested it :)

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
