### PR TITLE
We should store the RSA key for the edge cluster sooner.

### DIFF
--- a/deploy-edgecluster/verify.sh
+++ b/deploy-edgecluster/verify.sh
@@ -35,6 +35,15 @@ function check_aci() {
         exit 1
     else
         echo "AgentClusterInstall for ${cluster} verified"
+        oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} secret/${cluster}-keypair >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            echo "The RSA key for ${cluster} is already stored on the hub"
+        else
+            echo "Storing the RSA key on the hub"
+            export RSA_KEY_FILE="${WORKDIR}/${cluster}/${cluster}-rsa.key"
+            export RSA_PUB_FILE="${WORKDIR}/${cluster}/${cluster}-rsa.key.pub"
+            oc --kubeconfig=${KUBECONFIG_HUB} -n ${cluster} create secret generic ${cluster}-keypair --from-file=id_rsa.key=${RSA_KEY_FILE} --from-file=id_rsa.pub=${RSA_PUB_FILE}
+        fi
     fi
 }
 

--- a/finish-deployment/deploy.sh
+++ b/finish-deployment/deploy.sh
@@ -129,12 +129,11 @@ function recover_edgecluster_files() {
 }
 
 function store_rsa_secrets() {
-    # Function to save the RSA Key-Pair into the Hub
+    # Function to save the RSA Key-Pair into the Edge
     cluster=${1}
-    echo ">>>> Creating edgecluster cluster Keypair on Hub and Edge-cluster ${cluster} "
+    echo ">>>> Creating edgecluster cluster Keypair on Edge-cluster ${cluster} "
     echo ">> Secret name: ${cluster}-keypair"
     echo ">> Namespace: ${cluster}"
-    oc --kubeconfig=${KUBECONFIG_HUB} -n ${cluster} create secret generic ${cluster}-keypair --from-file=id_rsa.key=${RSA_KEY_FILE} --from-file=id_rsa.pub=${RSA_PUB_FILE}
     oc --kubeconfig=${EDGE_KUBECONFIG} -n default create secret generic cluster-ssh-keypair --from-file=id_rsa.key=${RSA_KEY_FILE} --from-file=id_rsa.pub=${RSA_PUB_FILE}
 }
 


### PR DESCRIPTION
Currently the RSA key is stored at the very end. If the pipeline
fails sooner - the key is re-generated but the new SSH key won't
work with the installed nodes and tasks using ssh to connect to
nodes will fail.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
