### PR TITLE
Revert "Revert "MGMT-10030: Custom registry ""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ run-pipeline-task:
 			    -w name=ztp,emptyDir="" \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
-    			--use-param-defaults $(TASK) && \
-	tkn tr logs -L -n edgecluster-deployer -f
+    			--use-param-defaults $(TASK) \
+    			--showlog
 
 run-hub-lvmo-task:
 	tkn task start -n edgecluster-deployer \
@@ -117,8 +117,8 @@ run-hub-lvmo-task:
 			    -w name=ztp,emptyDir="" \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
-    			--use-param-defaults hub-deploy-lvmo && \
-	tkn tr logs -L -n edgecluster-deployer -f
+    			--use-param-defaults hub-deploy-lvmo \
+    			--showlog
 
 
 deploy-pipe-hub-mce-sno: run-hub-lvmo-task
@@ -130,8 +130,8 @@ deploy-pipe-hub-mce-sno: run-hub-lvmo-task
 			-w name=ephemeral,emptyDir="" \
 			--timeout 5h \
 			--pod-template ./pipelines/resources/common/pod-template.yaml \
-			--use-param-defaults deploy-ztp-hub-mce  && \
-	tkn pr logs -L -n edgecluster-deployer -f
+			--use-param-defaults deploy-ztp-hub-mce  \
+			--showlog
 
 deploy-pipe-hub-mce-compact: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
@@ -141,8 +141,8 @@ deploy-pipe-hub-mce-compact: run-hub-lvmo-task
 			-w name=ztp,claimName=ztp-pvc \
 			--timeout 5h \
 			--pod-template ./pipelines/resources/common/pod-template.yaml \
-			--use-param-defaults deploy-ztp-hub-mce  && \
-	tkn pr logs -L -n edgecluster-deployer -f
+			--use-param-defaults deploy-ztp-hub-mce \
+			--showlog
 
 deploy-pipe-hub-sno: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
@@ -152,8 +152,8 @@ deploy-pipe-hub-sno: run-hub-lvmo-task
 			-w name=ztp,claimName=ztp-pvc \
 			--timeout 5h \
 			--pod-template ./pipelines/resources/common/pod-template.yaml \
-			--use-param-defaults deploy-ztp-hub  && \
-	tkn pr logs -L -n edgecluster-deployer -f
+			--use-param-defaults deploy-ztp-hub \
+			--showlog
 
 deploy-pipe-hub-compact: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
@@ -163,8 +163,8 @@ deploy-pipe-hub-compact: run-hub-lvmo-task
 			-w name=ztp,claimName=ztp-pvc \
 			--timeout 5h \
 			--pod-template ./pipelines/resources/common/pod-template.yaml \
-			--use-param-defaults deploy-ztp-hub  && \
-	tkn pr logs -L -n edgecluster-deployer -f
+			--use-param-defaults deploy-ztp-hub \
+			--showlog
 
 deploy-pipe-edgecluster-sno:
 	tkn pipeline start -n edgecluster-deployer \
@@ -174,8 +174,8 @@ deploy-pipe-edgecluster-sno:
     			-w name=ztp,claimName=ztp-pvc \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
-    			--use-param-defaults deploy-ztp-edgeclusters-sno && \
-	tkn pr logs -L -n edgecluster-deployer -f
+    			--use-param-defaults deploy-ztp-edgeclusters-sno \
+    			--showlog
 
 deploy-pipe-edgecluster-compact:
 	tkn pipeline start -n edgecluster-deployer \
@@ -185,8 +185,8 @@ deploy-pipe-edgecluster-compact:
     			-w name=ztp,claimName=ztp-pvc \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
-    			--use-param-defaults deploy-ztp-edgeclusters && \
-	tkn pr logs -L -n edgecluster-deployer -f
+    			--use-param-defaults deploy-ztp-edgeclusters \
+    			--showlog
 
 deploy-pipe-hub-ci:
 	tkn pipeline start -n edgecluster-deployer \
@@ -196,8 +196,8 @@ deploy-pipe-hub-ci:
 			-w name=ztp,claimName=ztp-pvc \
 			--timeout 5h \
 			--pod-template ./pipelines/resources/common/pod-template.yaml \
-			--use-param-defaults deploy-ztp-hub  && \
-	tkn pr logs -L -n edgecluster-deployer -f
+			--use-param-defaults deploy-ztp-hub \
+			--showlog
 
 deploy-pipe-edgecluster-sno-ci:
 	tkn pipeline start -n edgecluster-deployer \
@@ -207,8 +207,8 @@ deploy-pipe-edgecluster-sno-ci:
     			-w name=ztp,claimName=ztp-pvc \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
-    			--use-param-defaults deploy-ztp-edgeclusters-sno && \
-	tkn pr logs -L -n edgecluster-deployer -f
+    			--use-param-defaults deploy-ztp-edgeclusters-sno \
+    			--showlog
 
 deploy-pipe-edgecluster-compact-ci:
 	tkn pipeline start -n edgecluster-deployer \
@@ -218,8 +218,8 @@ deploy-pipe-edgecluster-compact-ci:
     			-w name=ztp,claimName=ztp-pvc \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
-    			--use-param-defaults deploy-ztp-edgeclusters && \
-	tkn pr logs -L -n edgecluster-deployer -f
+    			--use-param-defaults deploy-ztp-edgeclusters \
+    			--showlog
 
 bootstrap:
 	cd ${PWD}/pipelines && \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 FULL_PIPE_IMAGE_TAG=$(PIPE_IMAGE):$(BRANCH)
 FULL_UI_IMAGE_TAG=$(UI_IMAGE):$(BRANCH)
 
-.PHONY: all-images pipe-image pipe-image-ci ui-image ui-image-ci all-hub-sno all-hub-compact all-edgecluster-sno all-edgecluster-compact build-pipe-image build-ui-image push-pipe-image push-ui-image doc build-hub-sno build-hub-compact wait-for-hub-sno deploy-pipe-hub-sno deploy-pipe-hub-compact build-edgecluster-sno build-edgecluster-compact build-edgecluster-sno-2nics build-edgecluster-compact-2nics deploy-pipe-edgecluster-sno deploy-pipe-edgecluster-compact bootstrap bootstrap-ci deploy-pipe-hub-mce-sno deploy-pipe-hub-mce-compact deploy-pipe-hub-ci deploy-pipe-hub-ci deploy-pipe-edgecluster-sno-ci deploy-pipe-edgecluster-compact-ci all-hub-sno-ci all-hub-compact-ci all-edgecluster-sno-ci all-edgecluster-compact-ci all-images-ci run-pipeline-task
+.PHONY: all-images pipe-image pipe-image-ci ui-image ui-image-ci all-hub-sno all-hub-compact all-edgecluster-sno all-edgecluster-compact build-pipe-image build-ui-image push-pipe-image push-ui-image doc build-hub-sno build-hub-compact wait-for-hub-sno deploy-pipe-hub-sno deploy-pipe-hub-compact build-edgecluster-sno build-edgecluster-compact build-edgecluster-sno-2nics build-edgecluster-compact-2nics deploy-pipe-edgecluster-sno deploy-pipe-edgecluster-compact bootstrap bootstrap-ci deploy-pipe-hub-mce-sno deploy-pipe-hub-mce-compact deploy-pipe-hub-ci deploy-pipe-hub-ci deploy-pipe-edgecluster-sno-ci deploy-pipe-edgecluster-compact-ci all-hub-sno-ci all-hub-compact-ci all-edgecluster-sno-ci all-edgecluster-compact-ci all-images-ci run-pipeline-task run-hub-lvmo-task
 .EXPORT_ALL_VARIABLES:
 
 all-images: pipe-image ui-image
@@ -103,13 +103,25 @@ run-pipeline-task:
     			-p ztp-container-image="$(PIPE_IMAGE):$(BRANCH)" \
     			-p edgeclusters-config="$$(cat $(EDGECLUSTERS_FILE))" \
     			-p kubeconfig=${KUBECONFIG} \
-			-w name=ztp,emptyDir="" \
+			    -w name=ztp,emptyDir="" \
     			--timeout 5h \
     			--pod-template ./pipelines/resources/common/pod-template.yaml \
     			--use-param-defaults $(TASK) && \
 	tkn tr logs -L -n edgecluster-deployer -f
 
-deploy-pipe-hub-mce-sno:
+run-hub-lvmo-task:
+	tkn task start -n edgecluster-deployer \
+    			-p ztp-container-image="$(PIPE_IMAGE):$(BRANCH)" \
+    			-p edgeclusters-config="$$(cat $(EDGECLUSTERS_FILE))" \
+    			-p kubeconfig=${KUBECONFIG} \
+			    -w name=ztp,emptyDir="" \
+    			--timeout 5h \
+    			--pod-template ./pipelines/resources/common/pod-template.yaml \
+    			--use-param-defaults hub-deploy-lvmo && \
+	tkn tr logs -L -n edgecluster-deployer -f
+
+
+deploy-pipe-hub-mce-sno: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
 			-p ztp-container-image="$(PIPE_IMAGE):$(BRANCH)" \
 			-p edgeclusters-config="$$(cat $(EDGECLUSTERS_FILE))" \
@@ -121,7 +133,7 @@ deploy-pipe-hub-mce-sno:
 			--use-param-defaults deploy-ztp-hub-mce  && \
 	tkn pr logs -L -n edgecluster-deployer -f
 
-deploy-pipe-hub-mce-compact:
+deploy-pipe-hub-mce-compact: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
 			-p ztp-container-image="$(PIPE_IMAGE):$(BRANCH)" \
 			-p edgeclusters-config="$$(cat $(EDGECLUSTERS_FILE))" \
@@ -132,7 +144,7 @@ deploy-pipe-hub-mce-compact:
 			--use-param-defaults deploy-ztp-hub-mce  && \
 	tkn pr logs -L -n edgecluster-deployer -f
 
-deploy-pipe-hub-sno:
+deploy-pipe-hub-sno: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
 			-p ztp-container-image="$(PIPE_IMAGE):$(BRANCH)" \
 			-p edgeclusters-config="$$(cat $(EDGECLUSTERS_FILE))" \
@@ -143,7 +155,7 @@ deploy-pipe-hub-sno:
 			--use-param-defaults deploy-ztp-hub  && \
 	tkn pr logs -L -n edgecluster-deployer -f
 
-deploy-pipe-hub-compact:
+deploy-pipe-hub-compact: run-hub-lvmo-task
 	tkn pipeline start -n edgecluster-deployer \
 			-p ztp-container-image="$(PIPE_IMAGE):$(BRANCH)" \
 			-p edgeclusters-config="$$(cat $(EDGECLUSTERS_FILE))" \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 FULL_PIPE_IMAGE_TAG=$(PIPE_IMAGE):$(BRANCH)
 FULL_UI_IMAGE_TAG=$(UI_IMAGE):$(BRANCH)
 
-.PHONY: all-images pipe-image pipe-image-ci ui-image ui-image-ci all-hub-sno all-hub-compact all-edgecluster-sno all-edgecluster-compact build-pipe-image build-ui-image push-pipe-image push-ui-image doc build-hub-sno build-hub-compact wait-for-hub-sno deploy-pipe-hub-sno deploy-pipe-hub-compact build-edgecluster-sno build-edgecluster-compact build-edgecluster-sno-2nics build-edgecluster-compact-2nics deploy-pipe-edgecluster-sno deploy-pipe-edgecluster-compact bootstrap bootstrap-ci deploy-pipe-hub-mce-sno deploy-pipe-hub-mce-compact deploy-pipe-hub-ci deploy-pipe-hub-ci deploy-pipe-edgecluster-sno-ci deploy-pipe-edgecluster-compact-ci all-hub-sno-ci all-hub-compact-ci all-edgecluster-sno-ci all-edgecluster-compact-ci all-images-ci run-pipeline-task run-hub-lvmo-task
+.PHONY: all-images pipe-image pipe-image-ci ui-image ui-image-ci all-hub-sno all-hub-compact all-edgecluster-sno all-edgecluster-compact build-pipe-image build-ui-image push-pipe-image push-ui-image doc build-hub-sno build-hub-compact wait-for-hub-sno deploy-pipe-hub-sno deploy-pipe-hub-compact build-edgecluster-sno build-edgecluster-compact build-edgecluster-sno-2nics build-edgecluster-compact-2nics deploy-pipe-edgecluster-sno deploy-pipe-edgecluster-compact bootstrap bootstrap-ci deploy-pipe-hub-mce-sno deploy-pipe-hub-mce-compact deploy-pipe-hub-ci deploy-pipe-hub-ci deploy-pipe-edgecluster-sno-ci deploy-pipe-edgecluster-compact-ci all-hub-sno-ci all-hub-compact-ci all-edgecluster-sno-ci all-edgecluster-compact-ci all-images-ci run-pipeline-task run-hub-lvmo-task build-hub-sno-custom build-edgecluster-sno-2nics-custom build-edgecluster-compact-2nics-custom
 .EXPORT_ALL_VARIABLES:
 
 all-images: pipe-image ui-image
@@ -74,6 +74,10 @@ build-hub-sno:
 	cd ${PWD}/hack/deploy-hub-local && \
 	./build-hub.sh  $(PULL_SECRET) $(OCP_VERSION) $(ACM_VERSION) $(ODF_VERSION) sno
 
+build-hub-sno-custom:
+	cd ${PWD}/hack/deploy-hub-local && \
+	./build-hub.sh  $(PULL_SECRET) $(OCP_VERSION) $(ACM_VERSION) $(ODF_VERSION) sno $(REGISTRY)
+
 build-hub-compact:
 	cd ${PWD}/hack/deploy-hub-local && \
 	./build-hub.sh  $(PULL_SECRET) $(OCP_VERSION) $(ACM_VERSION) $(ODF_VERSION) compact
@@ -93,6 +97,14 @@ build-edgecluster-sno-2nics:
 build-edgecluster-compact-2nics:
 	cd ${PWD}/hack/deploy-hub-local && \
 	./build-edgecluster.sh  $(PULL_SECRET) $(OCP_VERSION) $(ACM_VERSION) $(ODF_VERSION) compact false
+
+build-edgecluster-sno-2nics-custom:
+	cd ${PWD}/hack/deploy-hub-local && \
+	./build-edgecluster.sh  $(PULL_SECRET) $(OCP_VERSION) $(ACM_VERSION) $(ODF_VERSION) sno false $(REGISTRY)
+
+build-edgecluster-compact-2nics-custom:
+	cd ${PWD}/hack/deploy-hub-local && \
+	./build-edgecluster.sh  $(PULL_SECRET) $(OCP_VERSION) $(ACM_VERSION) $(ODF_VERSION) compact false $(REGISTRY)
 
 wait-for-hub-sno:
 	${PWD}/shared-utils/wait_for_sno_mco.sh &

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -208,7 +208,7 @@ elif [[ ${1} == "edgecluster" ]]; then
           ready=false
           echo "DEBUG: oc --kubeconfig=${EDGE_KUBECONFIG} get route -n ${REGISTRY} ${REGISTRY}-quay -o jsonpath={'.status.ingress[0].host'}"
           while [ "$timeout" -lt "100" ]; do
-              if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route  -n ${REGISTRY} ${REGISTRY}-quay 2> /dev/null ]]; then
+              if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route  -n ${REGISTRY} ${REGISTRY}-quay 2> /dev/null) ]]; then
               ready=true
               break
               fi

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -204,7 +204,7 @@ elif [[ ${1} == "edgecluster" ]]; then
         echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
         timeout=0
         ready=false
-        while [ "$timeout" -lt "1000" ]; do
+        while [ "$timeout" -lt "100" ]; do
             if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} pod -n openshift-apiserver | grep Running | wc -l) -gt 0 ]]; then
             ready=true
             break

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -68,13 +68,16 @@ function trust_internal_registry() {
     if [[ ${1} == 'hub' ]]; then
         KBKNFG=${KUBECONFIG_HUB}
         clus="hub"
-		MYREGISTRY="$(oc --kubeconfig=${KBKNFG} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
-		REGISTRY_NAME=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f1 )
-	elif [[ ${1} == 'edgecluster' ]]; then
+		    MYREGISTRY="$(oc --kubeconfig=${KBKNFG} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
+		    if [[ ${CUSTOM_REGISTRY} != "true" ]] then
+		      CUSTOM_REGISTRY_URL=${MYREGISTRY}
+		    fi
+		    REGISTRY_NAME=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f1 )
+	  elif [[ ${1} == 'edgecluster' ]]; then
         KBKNFG=${EDGE_KUBECONFIG}
         clus=${2}
         MYREGISTRY=$(oc --kubeconfig=${KBKNFG} get route -n ztpfw-registry ztpfw-registry-quay -o jsonpath='{.spec.host}')
-		REGISTRY_NAME="${MYREGISTRY}"
+		    REGISTRY_NAME="${MYREGISTRY}"
     fi
 
     export PATH_CA_CERT="/etc/pki/ca-trust/source/anchors/internal-registry-${clus}.crt"

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -229,24 +229,25 @@ elif [[ ${1} == "edgecluster" ]]; then
           export OCP_DESTINATION_REGISTRY_IMAGE_NS=ocp4/openshift4
           ## OCP INDEX IMAGE
           export OCP_DESTINATION_INDEX="${DESTINATION_REGISTRY}/${OCP_DESTINATION_REGISTRY_IMAGE_NS}:${OC_OCP_TAG}"
+
+          ## OLM Sync vars
+          export SOURCE_REGISTRY="$(oc --kubeconfig=${KUBECONFIG_HUB} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
+
+          ## NS where the OLM images will be mirrored
+          export OLM_DESTINATION_REGISTRY_IMAGE_NS=olm
+          ## Image name where the OLM INDEX for RH OPERATORS image will be mirrored
+          export OLM_DESTINATION_REGISTRY_INDEX_NS=${OLM_DESTINATION_REGISTRY_IMAGE_NS}/redhat-operator-index
+
+          export SOURCE_INDEX="${SOURCE_REGISTRY}/${OLM_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
+          export OLM_DESTINATION_INDEX="${DESTINATION_REGISTRY}/${OLM_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
+
+          ## NS where the OLM CERTIFIED images will be mirrored
+          export OLM_CERTIFIED_DESTINATION_REGISTRY_IMAGE_NS=olm
+          ## Image name where the OLM INDEX for RH OPERATORS image will be mirrored
+          export OLM_CERTIFIED_DESTINATION_REGISTRY_INDEX_NS=${OLM_CERTIFIED_DESTINATION_REGISTRY_IMAGE_NS}/certified-operator-index
+
+          export CERTIFIED_SOURCE_INDEX="${SOURCE_REGISTRY}/${OLM_CERTIFIED_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
+          export OLM_CERTIFIED_DESTINATION_INDEX="${DESTINATION_REGISTRY}/${OLM_CERTIFIED_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
         fi
-        ## OLM Sync vars
-        export SOURCE_REGISTRY="$(oc --kubeconfig=${KUBECONFIG_HUB} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
-        
-        ## NS where the OLM images will be mirrored
-        export OLM_DESTINATION_REGISTRY_IMAGE_NS=olm
-        ## Image name where the OLM INDEX for RH OPERATORS image will be mirrored
-        export OLM_DESTINATION_REGISTRY_INDEX_NS=${OLM_DESTINATION_REGISTRY_IMAGE_NS}/redhat-operator-index
-
-        export SOURCE_INDEX="${SOURCE_REGISTRY}/${OLM_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
-        export OLM_DESTINATION_INDEX="${DESTINATION_REGISTRY}/${OLM_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
-
-        ## NS where the OLM CERTIFIED images will be mirrored
-        export OLM_CERTIFIED_DESTINATION_REGISTRY_IMAGE_NS=olm
-        ## Image name where the OLM INDEX for RH OPERATORS image will be mirrored
-        export OLM_CERTIFIED_DESTINATION_REGISTRY_INDEX_NS=${OLM_CERTIFIED_DESTINATION_REGISTRY_IMAGE_NS}/certified-operator-index
-
-        export CERTIFIED_SOURCE_INDEX="${SOURCE_REGISTRY}/${OLM_CERTIFIED_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
-        export OLM_CERTIFIED_DESTINATION_INDEX="${DESTINATION_REGISTRY}/${OLM_CERTIFIED_DESTINATION_REGISTRY_INDEX_NS}:v${OC_OCP_VERSION_MIN}"
     fi
 fi

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -202,17 +202,18 @@ elif [[ ${1} == "edgecluster" ]]; then
           echo "Registry NS exists so, we can continue with the workflow"
           ## Common
           ## FIX the race condition where the MCO is restarting services and get lost the route query
-          echo ">>>> Check apiserver to ensure is available"
+          echo ">>>> Check route to ensure is available"
           echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
           timeout=0
           ready=false
           echo "DEBUG: oc --kubeconfig=${EDGE_KUBECONFIG} get route -n ${REGISTRY} ${REGISTRY}-quay -o jsonpath={'.status.ingress[0].host'}"
           while [ "$timeout" -lt "100" ]; do
-              if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route  -n ${REGISTRY} ${REGISTRY}-quay | wc -l) -gt 0 ]]; then
+              if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route  -n ${REGISTRY} ${REGISTRY}-quay 2> /dev/null ]]; then
               ready=true
               break
               fi
               sleep 5
+              echo "Waiting to get the registry route available"
               timeout=$((timeout + 1))
           done
 

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -197,9 +197,11 @@ elif [[ ${1} == "edgecluster" ]]; then
         echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
         echo "HUB: ${KUBECONFIG_HUB}"
         echo "EDGE: ${EDGE_KUBECONFIG}"
+        echo "REGISTRY NS: ${REGISTRY}"
         ## Common
         export DESTINATION_REGISTRY="$(oc --kubeconfig=${EDGE_KUBECONFIG} get route -n ${REGISTRY} ${REGISTRY}-quay -o jsonpath={'.status.ingress[0].host'})"
         ## OCP Sync vars
+        echo "DESTIONATION_REGISTRY: ${DESTINATION_REGISTRY}"
         export OPENSHIFT_RELEASE_IMAGE="$(oc --kubeconfig=${KUBECONFIG_HUB} get clusterimageset --no-headers openshift-v${OC_OCP_VERSION_FULL} -o jsonpath={.spec.releaseImage})"
         ## The NS for INDEX and IMAGE will be the same here, this is why there is only 1
         export OCP_DESTINATION_REGISTRY_IMAGE_NS=ocp4/openshift4

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -69,7 +69,7 @@ function trust_internal_registry() {
         KBKNFG=${KUBECONFIG_HUB}
         clus="hub"
 		    MYREGISTRY="$(oc --kubeconfig=${KBKNFG} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
-		    if [[ ${CUSTOM_REGISTRY} != "true" ]] then
+		    if [[ ${CUSTOM_REGISTRY} != "true" ]]; then
 		      CUSTOM_REGISTRY_URL=${MYREGISTRY}
 		    fi
 		    REGISTRY_NAME=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f1 )

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -68,11 +68,13 @@ function trust_internal_registry() {
     if [[ ${1} == 'hub' ]]; then
         KBKNFG=${KUBECONFIG_HUB}
         clus="hub"
-        MYREGISTRY=$(oc --kubeconfig=${KBKNFG} get route -n ztpfw-registry ztpfw-registry -o jsonpath='{.spec.host}')
-    elif [[ ${1} == 'edgecluster' ]]; then
+		MYREGISTRY="$(oc --kubeconfig=${KBKNFG} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
+		REGISTRY_NAME=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f1 )
+	elif [[ ${1} == 'edgecluster' ]]; then
         KBKNFG=${EDGE_KUBECONFIG}
         clus=${2}
         MYREGISTRY=$(oc --kubeconfig=${KBKNFG} get route -n ztpfw-registry ztpfw-registry-quay -o jsonpath='{.spec.host}')
+		REGISTRY_NAME="${MYREGISTRY}"
     fi
 
     export PATH_CA_CERT="/etc/pki/ca-trust/source/anchors/internal-registry-${clus}.crt"
@@ -82,15 +84,16 @@ function trust_internal_registry() {
     echo ">> Mode: ${1}"
     echo ">> Cluster: ${clus}"
 
-    if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
-        ## Update trusted CA from Helper
-        #TODO after sync pull secret global because crictl can't use flags and uses the generic with https://access.redhat.com/solutions/4902871
-        export CA_CERT_DATA=$(oc --kubeconfig=${KBKNFG} get secret -n openshift-ingress router-certs-default -o go-template='{{index .data "tls.crt"}}')
-        echo ">> Cert: ${PATH_CA_CERT}"
+
+    ## Update trusted CA from Helper
+    #TODO after sync pull secret global because crictl can't use flags and uses the generic with https://access.redhat.com/solutions/4902871
+    if [[ ${CUSTOM_REGISTRY} == "true" ]] && [[ "${1}" == "hub"  ]]; then
+        export CA_CERT_DATA=$(openssl s_client -connect ${CUSTOM_REGISTRY_URL} -showcerts < /dev/null | openssl x509 | base64 | tr -d '\n')
     else
-        export CA_CERT_DATA=$(openssl s_client -connect ${LOCAL_REG} -showcerts </dev/null | openssl x509 | base64 | tr -d '\n')
-        MYREGISTRY=${LOCAL_REG}
+		export CA_CERT_DATA=$(oc --kubeconfig=${KBKNFG} get secret -n openshift-ingress router-certs-default -o go-template='{{index .data "tls.crt"}}')
+
     fi
+    echo ">> Cert: ${PATH_CA_CERT}"
 
     ## Update trusted CA from Helper
     echo "${CA_CERT_DATA}" | base64 -d >"${PATH_CA_CERT}"
@@ -100,9 +103,27 @@ function trust_internal_registry() {
     echo
 
     # Add certificate to OpenShift configuration
-
-    oc --kubeconfig=${KBKNFG} create configmap ztpfwregistry -n openshift-config --from-file=${MYREGISTRY}=${PATH_CA_CERT}
+    oc --kubeconfig=${KBKNFG} create configmap ztpfwregistry -n openshift-config --from-file=${REGISTRY_NAME}=${PATH_CA_CERT}
     oc --kubeconfig=${KBKNFG} patch image.config.openshift.io/cluster --patch '{"spec":{"additionalTrustedCA":{"name":"ztpfwregistry"}}}' --type=merge
+
+}
+
+function get_external_registry_cert() { 
+    KBKNFG=${EDGE_KUBECONFIG}
+    echo "INFO: Getting external registry cert"
+    export CA_CERT_DATA=$(openssl s_client -connect ${CUSTOM_REGISTRY_URL} -showcerts < /dev/null | openssl x509 | base64 | tr -d '\n')
+
+    export PATH_CA_CERT="/etc/pki/ca-trust/source/anchors/external-registry-edge.crt"
+    echo "${CA_CERT_DATA}" | base64 -d >"${PATH_CA_CERT}"
+    echo "${CA_CERT_DATA}" | base64 -d >"${WORKDIR}/build/external-registry-edge.crt"
+
+    update-ca-trust extract
+
+    echo "INFO: updating openthift config with new certifecate"
+
+    MYREGISTRY=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f1 )
+    oc --kubeconfig=${KBKNFG} create configmap ztpfwregistry-external -n openshift-config --from-file=${MYREGISTRY}=${PATH_CA_CERT}
+    oc --kubeconfig=${KBKNFG} patch image.config.openshift.io/cluster --patch '{"spec":{"additionalTrustedCA":{"name":"ztpfwregistry-external"}}}' --type=merge
 
 }
 
@@ -144,11 +165,7 @@ if [[ ${1} == "hub" ]]; then
     export SOURCE_REGISTRY="quay.io"
     export SOURCE_INDEX="registry.redhat.io/redhat/redhat-operator-index:v${OC_OCP_VERSION_MIN}"
     export CERTIFIED_SOURCE_INDEX="registry.redhat.io/redhat/certified-operator-index:v${OC_OCP_VERSION_MIN}"
-    if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
-        export DESTINATION_REGISTRY="$(oc --kubeconfig=${KUBECONFIG_HUB} get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})"
-    else
-        export DESTINATION_REGISTRY=${LOCAL_REG}
-    fi
+    export DESTINATION_REGISTRY="$(oc get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
     # OLM
     ## NS where the OLM images will be mirrored
     export OLM_DESTINATION_REGISTRY_IMAGE_NS=olm
@@ -187,7 +204,8 @@ elif [[ ${1} == "edgecluster" ]]; then
         export OCP_DESTINATION_INDEX="${DESTINATION_REGISTRY}/${OCP_DESTINATION_REGISTRY_IMAGE_NS}:${OC_OCP_TAG}"
 
         ## OLM Sync vars
-        export SOURCE_REGISTRY="$(oc --kubeconfig=${KUBECONFIG_HUB} get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})"
+        export SOURCE_REGISTRY="$(oc --kubeconfig=${KUBECONFIG_HUB} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
+        
         ## NS where the OLM images will be mirrored
         export OLM_DESTINATION_REGISTRY_IMAGE_NS=olm
         ## Image name where the OLM INDEX for RH OPERATORS image will be mirrored

--- a/deploy-disconnected-registry/common.sh
+++ b/deploy-disconnected-registry/common.sh
@@ -204,8 +204,9 @@ elif [[ ${1} == "edgecluster" ]]; then
         echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
         timeout=0
         ready=false
+        echo "DEBUG: oc --kubeconfig=${EDGE_KUBECONFIG} get route -n ${REGISTRY} ${REGISTRY}-quay -o jsonpath={'.status.ingress[0].host'}"
         while [ "$timeout" -lt "100" ]; do
-            if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} pod -n openshift-apiserver | grep Running | wc -l) -gt 0 ]]; then
+            if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} route  -n ${REGISTRY} ${REGISTRY}-quay | wc -l) -gt 0 ]]; then
             ready=true
             break
             fi
@@ -214,7 +215,7 @@ elif [[ ${1} == "edgecluster" ]]; then
         done
 
         if [ "$ready" == "false" ]; then
-            echo "timeout waiting for apiserver after mco service restart..."
+            echo "timeout waiting for route after mco service restart..."
             exit 1
         fi
         export DESTINATION_REGISTRY="$(oc --kubeconfig=${EDGE_KUBECONFIG} get route -n ${REGISTRY} ${REGISTRY}-quay -o jsonpath={'.status.ingress[0].host'})"

--- a/deploy-disconnected-registry/deploy.sh
+++ b/deploy-disconnected-registry/deploy.sh
@@ -133,6 +133,9 @@ function deploy_registry() {
         oc --kubeconfig=${TARGET_KUBECONFIG} -n ${REGISTRY} apply -f ${REGISTRY_MANIFESTS}/service.yaml
         oc --kubeconfig=${TARGET_KUBECONFIG} -n ${REGISTRY} apply -f ${REGISTRY_MANIFESTS}/pvc-registry.yaml
         oc --kubeconfig=${TARGET_KUBECONFIG} -n ${REGISTRY} apply -f ${REGISTRY_MANIFESTS}/route.yaml
+        REGISTRY_URI="$(oc --kubeconfig=${KUBECONFIG_HUB} get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})"
+        oc --kubeconfig=${TARGET_KUBECONFIG} -n ${REGISTRY} create configmap ztpfw-config -o yaml --from-literal=uri=$(echo ${REGISTRY_URI} | base64 ) 
+
     elif [[ ${1} == 'edgecluster' ]]; then
         TARGET_KUBECONFIG=${EDGE_KUBECONFIG}
         source ./common.sh ${1}
@@ -187,11 +190,28 @@ function deploy_registry() {
         echo ">>>>>>>>>>> https://${ROUTE}/api/v1/user/initialize "
         APIURL="https://${ROUTE}/api/v1/user/initialize"
 
-        # Call quay API to enable the dummy user
-        echo ">> Calling quay API to enable the user"
-        RESULT=$(curl -X POST -k ${APIURL} --header 'Content-Type: application/json' --data '{ "username": "dummy", "password":"dummy123", "email": "quayadmin@example.com", "access_token": true}')
+       #  # Call quay API to enable the dummy user
+       #  echo ">> Calling quay API to enable the user"
+       #  RESULT=$(curl -X POST -k ${APIURL} --header 'Content-Type: application/json' --data '{ "username": "dummy", "password":"dummy123", "email": "quayadmin@example.com", "access_token": true}')
 
-        # Show result on screen
+		echo ">> INFO: Creating Quay Creds"
+		export REG_US="dummy"
+		export REG_PASS="dummy123"
+		export REG_EMAIL="quayadmin@example.com"
+
+		DATA_JSON_PATH="${OUTPUTDIR}/quay-user-update.json"
+		cp "${WORKDIR}/deploy-disconnected-registry/quay-manifests/quay-user-update.json" "${DATA_JSON_PATH}"
+
+		sed -i "s/QUAY_USER/${REG_US}/g" "${DATA_JSON_PATH}"
+		sed -i "s/QUAY_PASS/${REG_PASS}/g" "${DATA_JSON_PATH}"
+		sed -i "s/QUAY_EMAIL/${REG_EMAIL}/g" "${DATA_JSON_PATH}"
+
+		
+        # Call quay API to enable the dummy user
+        echo ">> INFO: Calling quay API to enable the user"
+        RESULT=$(curl -s -X POST -k ${APIURL} --header 'Content-Type: application/json' --data "@${DATA_JSON_PATH}")
+        
+		# Show result on screen
         echo ${RESULT}
 
         # example
@@ -206,17 +226,54 @@ function deploy_registry() {
             echo ">> Creating organization ${organization}"
             curl -X POST -k -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" ${APIURL} --data "{\"name\": \"${organization}\", \"email\": \"${organization}@redhat.com\"}"
         done
+
+		echo ">> INFO: updating pull secret" 
+		b64auth=$( echo "$REG_US:$REG_PASS" | base64 )
+		AUTHSTRING="{\"$ROUTE\": {\"auth\": \"$b64auth\"}}"
+
+		echo ">> INFO: getting pull secret"
+		oc get secret -n openshift-config pull-secret -ojsonpath='{.data.\.dockerconfigjson}' | base64 -d > "${OUTPUTDIR}/origin-pullsecret.json"
+
+		echo ">> INFO: Creating updated pull secret"
+		jq ".auths += $AUTHSTRING" < "${OUTPUTDIR}/origin-pullsecret.json" > "${OUTPUTDIR}/updated-pull-secret.json"
+
+		echo ">> INFO: pushing openshift config" 
+		oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson="${OUTPUTDIR}/updated-pull-secret.json"
     fi
 
 }
 
-function custom_registry() {
-    trust_internal_registry 'hub'
-    check_mcp 'hub'
-    render_file manifests/machine-config-certs-worker.yaml 'hub'
-    render_file manifests/machine-config-certs-master.yaml 'hub'
-    check_resource "mcp" "master" "Updated" "default" "${KUBECONFIG_HUB}"
+function deploy_custom_registry() {
+    if [[ ${1} == 'hub' ]]; then
+        TMP_REGISTRY_DOMAIN=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f1 )
+        TMP_REGISTRY_PORT=$( echo  ${CUSTOM_REGISTRY_URL} | cut -d":" -f2 )
+        TMP_REGISTRY_IP=$( dig  A +short ${TMP_REGISTRY_DOMAIN} | head -1)
 
+        echo "Create Endpoint"
+        TPL_MANIFEST="${WORKDIR}/deploy-disconnected-registry/manifests/custom-registry-endpoint.yaml"
+        MANIFESTCLONE="${WORKDIR}/build/custom-registry-endpoint.yaml"
+
+        cp -f ${TPL_MANIFEST} ${MANIFESTCLONE}
+        sed -i "s/TMP_REGISTRY_DOMAIN/${TMP_REGISTRY_DOMAIN}/g" ${MANIFESTCLONE}
+        sed -i "s/TMP_REGISTRY_IP/${TMP_REGISTRY_IP}/g" ${MANIFESTCLONE}
+        sed -i "s/TMP_REGISTRY_PORT/${TMP_REGISTRY_PORT}/g" ${MANIFESTCLONE}
+
+        echo "INFO: applying  Endpoint config"
+        cat ${MANIFESTCLONE} | yq e -
+        oc --kubeconfig=${KUBECONFIG_HUB} create namespace ${REGISTRY} 
+        oc --kubeconfig=${KUBECONFIG_HUB} apply -f ${MANIFESTCLONE} 
+
+        echo "INFO: Creating Route"
+        oc create route edge ztpfw-registry \
+            --kubeconfig=${KUBECONFIG_HUB} --namespace  ${REGISTRY}  \
+            --service=external-registry --port=${TMP_REGISTRY_PORT} \
+            --insecure-policy=Redirect \
+            --dry-run=client --hostname "${TMP_REGISTRY_DOMAIN}" \
+            --output=yaml | oc apply -f -
+
+        oc --kubeconfig=${KUBECONFIG_HUB} -n ${REGISTRY} create configmap ztpfw-config -o yaml --from-literal=uri=$(echo ${CUSTOM_REGISTRY_URL} | base64 ) 
+
+    fi
 }
 
 if [[ ${1} == 'hub' ]]; then
@@ -224,16 +281,18 @@ if [[ ${1} == 'hub' ]]; then
     if ! ./verify.sh 'hub'; then
         if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
             deploy_registry 'hub'
-            trust_internal_registry 'hub'
-            check_resource "deployment" "${REGISTRY}" "Available" "${REGISTRY}" "${KUBECONFIG_HUB}"
-            check_mcp 'hub'
-            render_file manifests/machine-config-certs-worker.yaml 'hub'
-            render_file manifests/machine-config-certs-master.yaml 'hub'
-            check_resource "mcp" "master" "Updated" "default" "${KUBECONFIG_HUB}"
-            check_resource "deployment" "${REGISTRY}" "Available" "${REGISTRY}" "${KUBECONFIG_HUB}"
-        else
-            custom_registry 'hub'
+        elif [[ ${CUSTOM_REGISTRY} == "true" ]]; then
+            deploy_custom_registry 'hub'
         fi
+
+        trust_internal_registry 'hub'
+        if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
+            check_resource "deployment" "${REGISTRY}" "Available" "${REGISTRY}" "${KUBECONFIG_HUB}"
+        fi
+        check_mcp 'hub'
+        render_file manifests/machine-config-certs-worker.yaml 'hub'
+        render_file manifests/machine-config-certs-master.yaml 'hub'
+        check_resource "mcp" "master" "Updated" "default" "${KUBECONFIG_HUB}"
     else
         echo ">>>> This step to deploy registry on Hub is not neccesary, everything looks ready"
     fi
@@ -255,6 +314,9 @@ elif [[ ${1} == 'edgecluster' ]]; then
 
         # Verify step
         if ! ./verify.sh 'edgecluster'; then
+            if [[ ${CUSTOM_REGISTRY} == "true" ]]; then
+                get_external_registry_cert
+            fi
             deploy_registry 'edgecluster' ${edgecluster}
             trust_internal_registry 'edgecluster' ${edgecluster}
 
@@ -262,6 +324,8 @@ elif [[ ${1} == 'edgecluster' ]]; then
             echo ">> Waiting for the registry Quay CR to be ready after updating the CA certificate"
             for dep in $LIST_DEP; do
                 echo ">> Waiting for deployment ${dep} in Quay operator to be ready"
+                echo "REGISTRY: ${REGISTRY}"
+                echo "dep: ${dep}"
                 check_resource "deployment" "${dep}" "Available" "${REGISTRY}" "${EDGE_KUBECONFIG}"
             done
 

--- a/deploy-disconnected-registry/deploy.sh
+++ b/deploy-disconnected-registry/deploy.sh
@@ -228,7 +228,7 @@ function deploy_registry() {
         done
 
 		echo ">> INFO: updating pull secret" 
-		b64auth=$( echo "$REG_US:$REG_PASS" | base64 )
+		b64auth=$( echo -n "$REG_US:$REG_PASS" | base64 )
 		AUTHSTRING="{\"$ROUTE\": {\"auth\": \"$b64auth\"}}"
 
 		echo ">> INFO: getting pull secret"

--- a/deploy-disconnected-registry/manifests/custom-registry-endpoint.yaml
+++ b/deploy-disconnected-registry/manifests/custom-registry-endpoint.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-registry
+  namespace: ztpfw-registry
+spec:
+  ports:
+    - protocol: TCP
+      name: external-registry-port
+      port: 8989
+      targetPort: TMP_REGISTRY_PORT
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-registry
+  namespace: ztpfw-registry
+subsets:
+  - addresses:
+      - ip: TMP_REGISTRY_IP
+    ports:
+      - port: TMP_REGISTRY_PORT
+        name: external-registry-port

--- a/deploy-disconnected-registry/manifests/pvc-registry.yaml
+++ b/deploy-disconnected-registry/manifests/pvc-registry.yaml
@@ -8,6 +8,6 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 200Gi
+      storage: 300Gi
   accessModes:
     - ReadWriteOnce

--- a/deploy-disconnected-registry/ocp-sync.sh
+++ b/deploy-disconnected-registry/ocp-sync.sh
@@ -42,17 +42,6 @@ function mirror_ocp() {
     echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
     echo
 
-    if [[ ${CUSTOM_REGISTRY} == "true" ]]; then
-        echo "Checking Private registry creds"
-        if [[ ! $(podman login ${LOCAL_REG} --authfile ${PULL_SECRET}) ]]; then
-            echo "ERROR: Failed to login to ${LOCAL_REG}, please check Pull Secret"
-            exit 1
-        else
-            echo "Login successfully to ${LOCAL_REG}"
-        fi
-    fi
-    #######
-
     # Empty log file
     >${OUTPUTDIR}/mirror-ocp.log
     SALIDA=1
@@ -87,12 +76,6 @@ if [[ ${1} == 'hub' ]]; then
     trust_internal_registry 'hub'
 
     if ! ./verify_ocp_sync.sh 'hub'; then
-
-        if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
-            oc create namespace ${REGISTRY} -o yaml --dry-run=client | oc apply -f -
-            # TODO: commented out the next line seems not needed
-            # export REGISTRY_NAME="$(oc get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})"
-        fi
         registry_login ${DESTINATION_REGISTRY}
         mirror_ocp 'hub' 'hub'
     else
@@ -124,10 +107,7 @@ elif [[ ${1} == 'edgecluster' ]]; then
             oc --kubeconfig=${EDGE_KUBECONFIG} create namespace ${REGISTRY} -o yaml --dry-run=client | oc apply -f -
 
             ## Logging into the Source and Destination registries
-            ${PODMAN_LOGIN_CMD} ${SOURCE_REGISTRY} -u ${REG_US} -p ${REG_PASS} --authfile=${PULL_SECRET}
-            ${PODMAN_LOGIN_CMD} ${SOURCE_REGISTRY} -u ${REG_US} -p ${REG_PASS}
-            ${PODMAN_LOGIN_CMD} ${DESTINATION_REGISTRY} -u ${REG_US} -p ${REG_PASS} --authfile=${PULL_SECRET}
-            ${PODMAN_LOGIN_CMD} ${DESTINATION_REGISTRY} -u ${REG_US} -p ${REG_PASS}
+			registry_login ${SOURCE_REGISTRY} 
             mirror_ocp 'edgecluster' ${edgecluster}
         else
             echo ">>>> This step to mirror ocp is not neccesary, everything looks ready: ${1}"

--- a/deploy-disconnected-registry/quay-manifests/quay-user-update.json
+++ b/deploy-disconnected-registry/quay-manifests/quay-user-update.json
@@ -1,0 +1,6 @@
+{ 
+	"username": "QUAY_USER", 
+	"password": "QUAY_PASS", 
+	"email": "QUAY_EMAIL", 
+	"access_token": true
+}

--- a/deploy-disconnected-registry/verify.sh
+++ b/deploy-disconnected-registry/verify.sh
@@ -24,13 +24,11 @@ if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
         #namespace or resources does not exist. Launching the step to create it...
         exit 1
     fi
+fi 
 
-    if [[ $(oc get --kubeconfig=${TG_KUBECONFIG} route -n ${REGISTRY} --no-headers | wc -l) -lt 1 ]]; then
-        exit 2
-    fi
-else
-    # Running with  Custom registry
-    exit 10
+if [[ $(oc get --kubeconfig=${TG_KUBECONFIG} route -n ${REGISTRY} --no-headers | wc -l) -lt 1 ]]; then
+    exit 2
 fi
+
 
 exit 0

--- a/deploy-edgecluster/configure_disconnected.sh
+++ b/deploy-edgecluster/configure_disconnected.sh
@@ -84,7 +84,7 @@ function icsp_mutate() {
     MAP=${1}
     DST_REG=${2}
     EDGE=${3}
-    HUB_REG_ROUTE="$(oc --kubeconfig=${KUBECONFIG_HUB} get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})"
+    HUB_REG_ROUTE="$(oc --kubeconfig=${KUBECONFIG_HUB} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)"
     export EDGE_MAPPING_FILE="${MAP%%.*}-${edgecluster}.txt"
     sed "s/${HUB_REG_ROUTE}/${DST_REG}/g" ${MAP} | tee "${MAP%%.*}-${edgecluster}.txt"
 }

--- a/deploy-hub-configs/deploy.sh
+++ b/deploy-hub-configs/deploy.sh
@@ -29,16 +29,14 @@ if ./verify.sh; then
     sed -i "s/HTTPD_SERVICE/${HTTPSERVICE}/g" 04-agent-service-config.yml
     pull=$(oc get secret -n openshift-config pull-secret -ojsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq -c)
     echo -n "  .dockerconfigjson: "\'$pull\' >>05-pullsecrethub.yml
-    if [[ ${CUSTOM_REGISTRY} == "false" ]]; then
-        REGISTRY=ztpfw-registry
-        LOCAL_REG="$(oc get route -n ${REGISTRY} ${REGISTRY} -o jsonpath={'.status.ingress[0].host'})" #TODO change it to use the global common variable importing here the source commons
-    fi
+    REGISTRY=ztpfw-registry
+    LOCAL_REG="$(oc --kubeconfig=${KUBECONFIG_HUB} get configmap  --namespace ${REGISTRY} ztpfw-config -o jsonpath='{.data.uri}' | base64 -d)" #TODO change it to use the global common variable importing here the source commons
     sed -i "s/CHANGEDOMAIN/${LOCAL_REG}/g" registryconf.txt
     if [[ ${CUSTOM_REGISTRY} == "true" ]]; then
-        export CA_CERT_DATA=$(openssl s_client -connect ${LOCAL_REG} -showcerts </dev/null | openssl x509)
-        echo "" >>01_Mirror_ConfigMap.yml
-        echo "  ca-bundle.crt: |" >>01_Mirror_ConfigMap.yml
-        echo -n "${CA_CERT_DATA}" | sed "s/^/    /" >>01_Mirror_ConfigMap.yml
+       export CA_CERT_DATA=$(openssl s_client -connect ${LOCAL_REG} -showcerts < /dev/null | openssl x509)
+       echo "" >>01_Mirror_ConfigMap.yml
+       echo "  ca-bundle.crt: |" >>01_Mirror_ConfigMap.yml
+       echo -n "${CA_CERT_DATA}" | sed "s/^/    /" >>01_Mirror_ConfigMap.yml
     else
         CABUNDLE=$(oc get cm -n openshift-image-registry kube-root-ca.crt --template='{{index .data "ca.crt"}}')
         echo "  ca-bundle.crt: |" >>01_Mirror_ConfigMap.yml

--- a/deploy-odf/deploy.sh
+++ b/deploy-odf/deploy.sh
@@ -122,6 +122,18 @@ if ! ./verify.sh; then
         fi
 	if [ "${NUM_M}" -eq "1" ];
 	then
+	  echo ">>>> Waiting for: Backingstore"
+    echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+    timeout=0
+    ready=false
+    while [ "$timeout" -lt "1000" ]; do
+      if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} -n openshift-storage backingstores.noobaa.io -ojsonpath='{.items[*].status.phase}') == "Ready" ]]; then
+        ready=true
+        break
+      fi
+      sleep 5
+      timeout=$((timeout + 1))
+    done
 		# By default the StorageCluster creates a Noobaa instances with a single volume of 50Gi for the
 		# pvPool. This is not enough for the mirror so we are increasing this number to 5
 		oc patch --kubeconfig=${EDGE_KUBECONFIG} -n openshift-storage BackingStore noobaa-default-backing-store --type json -p '[{"op": "add", "path": "/spec/pvPool/numVolumes", "value": 5}]'

--- a/documentation/ztp-for-factories/ztp-hub-factory-pipeline.adoc
+++ b/documentation/ztp-for-factories/ztp-hub-factory-pipeline.adoc
@@ -33,6 +33,11 @@ This step deploys a registry on the hub cluster. The substeps involved in this p
    * Sync the {product-title} and Operator Lifecycle Manager (OLM) images from Quay and Red Hat registries to the internal registry.
    * Update the pull secret globally.
 
+In case you have your own registry already deployed, you should add the next info to the config yaml file:
+`REGISTRY: <url-registry:port>`
+and update the pull secret with the registry entry (url, username and password ) in order to make easy the authentication in your own registry without credentials.
+In this scenario, your own registry will be used as the hub registry in the pipeline.
+
 Deploy RHACM::
 
 This step installs the Red Hat Advanced Cluster Manager and Assisted Installer on the {product-title} hub cluster. Red Hat Advanced Cluster Manager manages the deployment on many managed edge clusters.

--- a/documentation/ztp-for-factories/ztp-install-factory-edge-pipeline.adoc
+++ b/documentation/ztp-for-factories/ztp-install-factory-edge-pipeline.adoc
@@ -41,6 +41,7 @@ config:
   OC_OCP_VERSION: "4.10.9"
   OC_ACM_VERSION: "2.4"
   OC_OCS_VERSION: "4.9"
+  REGISTRY: myregistry.local:5000  <0>
 
 edgeclusters:
   - edgecluster1-name: <1>
@@ -149,6 +150,7 @@ edgeclusters:
         bmc_user: "user-bmc"
         bmc_pass: "user-pass"
 ----
+<0> This parameter is optional just in case you want to use your own registry already deployed. Remember, if you are using your own registry, the pull secret must contains the information related to the entry (url, username and password)
 <1> This option is configurable and sets the name of the edge cluster.
 <2> This value must match `master0`, `master1` or `master2`.
 <3> Optional: Interfaces to ignore in the host.

--- a/documentation/ztp-for-factories/ztp-install-factory-pipeline.adoc
+++ b/documentation/ztp-for-factories/ztp-install-factory-pipeline.adoc
@@ -28,11 +28,13 @@ config:
   OC_OCP_VERSION: "4.10.9" <1>
   OC_ACM_VERSION: "2.4" <2>
   OC_OCS_VERSION: "4.9" <3>
+  REGISTRY: my-own-registry.local:5000 <4>
 ----
 +
 <1> {product-title} version of the edge cluster.
 <2> Red Hat Advanced Cluster Management (RHACM) version.
 <3> The OpenShift Data Foundation (ODF) version.
+<4> This is an optional parameter to set up your own registry already deployed in the hub.
 
 . Start the hub cluster pipeline from the command line:
 +

--- a/hack/custom_registry/01_deploy_registry.sh
+++ b/hack/custom_registry/01_deploy_registry.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+export REGISTRY_NAME=$(hostname --long)
+export REGISTRY_USER=dummy
+export REGISTRY_PASS=dummy
+
+dnf -y install podman httpd httpd-tools jq bind-utils
+mkdir -p /opt/registry/{auth,certs,data,conf}
+cat <<EOF > /opt/registry/conf/config.yml
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+compatibility:
+  schema1:
+    enabled: true
+EOF
+cat /opt/registry/conf/config.yml
+cat /etc/hosts
+openssl req -newkey rsa:4096 -nodes -sha256 -keyout /opt/registry/certs/domain.key -x509 -days 365 -out /opt/registry/certs/domain.crt -subj "/C=US/ST=Madrid/L=San Bernardo/O=Karmalabs/OU=Guitar/CN=${REGISTRY_NAME}" -addext "subjectAltName=DNS:${REGISTRY_NAME}"
+cp /opt/registry/certs/domain.crt /etc/pki/ca-trust/source/anchors/
+update-ca-trust extract
+htpasswd -bBc /opt/registry/auth/htpasswd ${REGISTRY_USER} ${REGISTRY_PASS}
+podman create --name registry --net host --security-opt label=disable -v /opt/registry/data:/var/lib/registry:z -v /opt/registry/auth:/auth:z -v /opt/registry/conf/config.yml:/etc/docker/registry/config.yml -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry" -e "REGISTRY_HTTP_SECRET=ALongRandomSecretForRegistry" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -v /opt/registry/certs:/certs:z -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key ${REGISTRY_NAME}
+podman create --name registry --net host --security-opt label=disable -v /opt/registry/data:/var/lib/registry:z -v /opt/registry/auth:/auth:z -v /opt/registry/conf/config.yml:/etc/docker/registry/config.yml -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry" -e "REGISTRY_HTTP_SECRET=ALongRandomSecretForRegistry" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -v /opt/registry/certs:/certs:z -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key registry:2
+podman start registry

--- a/hack/custom_registry/02_update_pullsecret.sh
+++ b/hack/custom_registry/02_update_pullsecret.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+export REGISTRY_NAME=$(hostname --long)
+export REGISTRY_USER=dummy
+export REGISTRY_PASS=dummy
+
+echo "Original values:"
+echo "Registry Name: ${REGISTRY_NAME}"
+echo "Registry User: ${REGISTRY_USER}"
+echo "Registry Pass: ${REGISTRY_PASS}"
+echo
+echo "creating the pull secret entry"
+b64auth=$( echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64 )
+AUTHSTRING="{\"$REGISTRY_NAME:5000\": {\"auth\": \"$b64auth\"}}"
+echo
+
+echo "getting pull secret"
+oc get secret -n openshift-config pull-secret -ojsonpath='{.data.\.dockerconfigjson}' | base64 -d > origin-pullsecret.json
+echo
+echo "Creating updated pull secret"
+jq ".auths += $AUTHSTRING" < origin-pullsecret.json > updated-pull-secret.json
+echo
+echo "the new pull secret before pushing to openshift config:"
+cat updated-pull-secret.json
+echo
+echo "pushing openshift config"
+oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=updated-pull-secret.json

--- a/hack/custom_registry/README
+++ b/hack/custom_registry/README
@@ -4,4 +4,5 @@ Steps to create a custom registry for lab purposes:
 
 2-. ./02_update_pullsecret.sh -> Using OC and getting the current pull secret loaded into the Openshift cluster, will be updated with the new entry after creating the Registry
 
-3-. Add entry (hostname --long) to dnsmasq in order to make it available to be resolved by hosts inside the cluster
+3-. Add entry (hostname --long) to dnsmasq in order to make it available to be resolved by hosts inside the cluster. In the lab environment, after changing dns should restart services doing something like:
+    systemctl restart dnsmasq libvirtd sushy

--- a/hack/custom_registry/README
+++ b/hack/custom_registry/README
@@ -1,0 +1,7 @@
+Steps to create a custom registry for lab purposes:
+
+1-. ./01_deploy_registry.sh -> Will create the podman container with a docker registry using the host long name (hostname --long command)
+
+2-. ./02_update_pullsecret.sh -> Using OC and getting the current pull secret loaded into the Openshift cluster, will be updated with the new entry after creating the Registry
+
+3-. Add entry (hostname --long) to dnsmasq in order to make it available to be resolved by hosts inside the cluster

--- a/hack/deploy-hub-local/build-edgecluster.sh
+++ b/hack/deploy-hub-local/build-edgecluster.sh
@@ -116,7 +116,7 @@ EOF
 
 # add registry from env REGISTRY
 if [[ ! -z "${_REGISTRY}" ]]; then
-    yq e '.config.REGISTRY = strenv(REGISTRY)' -i "${CLUSTER_NAME}.yaml"
+    yq e ".config.REGISTRY = strenv(REGISTRY)" -i "${CLUSTER_NAME}.yaml"
 fi
 
 # Create header for ${_CLUSTER_NAME}.yaml

--- a/hack/deploy-hub-local/build-edgecluster.sh
+++ b/hack/deploy-hub-local/build-edgecluster.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 set -m
 
-usage() { echo "Usage: $0 <pull-secret-file> <ocp-version(4.10.6)> <acm_version(2.4)> <odf_version(4.8)> [<hub_architecture(compact|sno)>] [<single_nic(true|false)>]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 <pull-secret-file> <ocp-version(4.10.6)> <acm_version(2.4)> <odf_version(4.8)> [<hub_architecture(compact|sno)>] [<single_nic(true|false)>] [<custom_registry_url>]" 1>&2; exit 1; }
 
 if [ $# -lt 4 ]; then
     usage
@@ -47,7 +47,7 @@ export HUB_ARCHITECTURE="${5:-compact}"
 export SINGLE_NIC="${6:-true}"
 export _CLUSTER_NAME=${CLUSTER_NAME:-edgecluster}
 export CLUSTER_IPS=""
-export _REGISTRY=${REGISTRY:-}
+export _REGISTRY=${7:-}
 
 for edgecluster in $(seq 0 $((CLUSTERS - 1))); do
   ip=$(dig +short api.${_CLUSTER_NAME}${edgecluster}-cluster.alklabs.local)
@@ -116,7 +116,7 @@ EOF
 
 # add registry from env REGISTRY
 if [[ ! -z "${_REGISTRY}" ]]; then
-    yq e ".config.REGISTRY = strenv(REGISTRY)" -i "${CLUSTER_NAME}.yaml"
+    yq e '.config.REGISTRY = "${_REGISTRY}"' -i "${CLUSTER_NAME}.yaml"
 fi
 
 # Create header for ${_CLUSTER_NAME}.yaml

--- a/hack/deploy-hub-local/build-edgecluster.sh
+++ b/hack/deploy-hub-local/build-edgecluster.sh
@@ -116,7 +116,9 @@ EOF
 
 # add registry from env REGISTRY
 if [[ ! -z "${_REGISTRY}" ]]; then
-    yq e '.config.REGISTRY = "${_REGISTRY}"' -i "${CLUSTER_NAME}.yaml"
+    cat <<EOF >>${_CLUSTER_NAME}.yaml
+  REGISTRY: ${_REGISTRY}
+EOF
 fi
 
 # Create header for ${_CLUSTER_NAME}.yaml

--- a/hack/deploy-hub-local/build-hub.sh
+++ b/hack/deploy-hub-local/build-hub.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -m
 
 usage() {
-    echo "Usage: $0 <pull-secret-file> <ocp-version(4.10.6)> <acm_version(2.4)> <odf_version(4.8)> <hub_architecture(installer|sno)>" 1>&2
+    echo "Usage: $0 <pull-secret-file> <ocp-version(4.10.6)> <acm_version(2.4)> <odf_version(4.8)> [<hub_architecture(compact|sno)>] [<custom_registry_url>]" 1>&2
     exit 1
 }
 
@@ -47,7 +47,7 @@ export OC_ACM_VERSION="${acm_version}"
 export OC_ODF_VERSION="${odf_version}"
 export HUB_ARCHITECTURE="${5:-compact}"
 export _CLUSTER_NAME=${CLUSTER_NAME:-edgecluster}
-export _REGISTRY=${REGISTRY:-}
+export _REGISTRY=${6:-}
 
 
 echo ">>>> Set the Pull Secret"
@@ -110,7 +110,7 @@ EOF
 
 # add registry from env REGISTRY
 if [[ ! -z "${_REGISTRY}" ]]; then
-    yq e '.config.REGISTRY = strenv(REGISTRY)' -i "${CLUSTER_NAME}.yaml"
+    yq e '.config.REGISTRY = "${_REGISTRY}"' -i "${CLUSTER_NAME}.yaml"
 fi
 
 # Create header for edgecluster.yaml

--- a/hack/deploy-hub-local/build-hub.sh
+++ b/hack/deploy-hub-local/build-hub.sh
@@ -110,7 +110,9 @@ EOF
 
 # add registry from env REGISTRY
 if [[ ! -z "${_REGISTRY}" ]]; then
-    yq e '.config.REGISTRY = "${_REGISTRY}"' -i "${CLUSTER_NAME}.yaml"
+    cat <<EOF >>${CLUSTER_NAME}.yaml
+  REGISTRY: ${_REGISTRY}
+EOF
 fi
 
 # Create header for edgecluster.yaml

--- a/hack/deploy-hub-local/build-hub.sh
+++ b/hack/deploy-hub-local/build-hub.sh
@@ -120,8 +120,7 @@ EOF
 
 cat "${CLUSTER_NAME}.yaml"
 
-echo ">>>> Create the PV and sushy and dns"
-./lab-nfs.sh
+echo ">>>> Launch the sushy script"
 ./lab-sushy.sh
 
 echo ">>>> EOF"

--- a/pipelines/resources/common/kustomization.yaml
+++ b/pipelines/resources/common/kustomization.yaml
@@ -2,4 +2,3 @@ resources:
   - common-pre-flight.yaml
   - common-pre-flight-edgeclusters.yaml
   - common-git-fetch.yaml
-  - pvc-template.yaml

--- a/shared-utils/common.sh
+++ b/shared-utils/common.sh
@@ -382,12 +382,11 @@ fi
 
 export ALLEDGECLUSTERS=$(yq e '(.edgeclusters[] | keys)[]' ${EDGECLUSTERS_FILE})
 
+export REGISTRY=ztpfw-registry
 export EDGECLUSTERS_REGISTRY=$(yq eval ".config.REGISTRY" ${EDGECLUSTERS_FILE} || null)
 if [[ ${EDGECLUSTERS_REGISTRY} == "" || ${EDGECLUSTERS_REGISTRY} == null ]]; then
     export CUSTOM_REGISTRY=false
-    export REGISTRY=ztpfw-registry
 else
     export CUSTOM_REGISTRY=true
-    REGISTRY=$(echo ${EDGECLUSTERS_REGISTRY} | cut -d"." -f1)
-    LOCAL_REG=${EDGECLUSTERS_REGISTRY}
+    export CUSTOM_REGISTRY_URL=${EDGECLUSTERS_REGISTRY}
 fi


### PR DESCRIPTION
This is the revert of the revert so we can test it, and build on top of it

Reverts rh-ecosystem-edge/ztp-pipeline-relocatable#550

Content/Features/Bugs of this PR:
- Fix some bugs discovered in the original Custom Registry (auth issues with PullSecret and unbound variables when we don't use CustomRegistry)
- New Folder hack/custom_registry where some new **Scripts** and **README** enables the possibility to deploy in a lab a custom registry to be tested. 
- Remove lab-nfs.sh + bootstrap step to create pv, because we're using now lvmo instead of NFS in the hub.
- Adding the task to deploy lvmo in the hub as a task in the MakeFile as pre-requirement:
![image](https://user-images.githubusercontent.com/9356454/187868732-215332be-f68a-41f2-a438-33902fd777b2.png)

- Modify the Makefile to enable the custom-registry as new targets (hub and edge) adding the REGISTRY as param instead of env variable:
![image](https://user-images.githubusercontent.com/9356454/187868448-06e84a9d-8fb3-47db-a23d-2db16c3da2d0.png)


### **TEST HUB WITHOUT CUSTOM MIRROR (BASE FEATURE):**
![image](https://user-images.githubusercontent.com/9356454/187477147-807bb2d0-fde6-4888-aa51-9036436730a8.png)

- No error now as @achuzhoy shown in his issue: https://issues.redhat.com/browse/MGMT-11783

**image tag tested**: revert-550-revert-465-MGMT-10030-registry
![image](https://user-images.githubusercontent.com/9356454/187475347-a335410b-6141-4853-b91b-0e76912d752a.png)

- No error with hub size disk (200 instead of 300):
![image](https://user-images.githubusercontent.com/9356454/187475835-49f9ec4d-cb36-444f-afb7-e507c01e11c7.png)

### **Test HUB with External Registry**

First of all, 
- Preparation for the new external custom registry with a container docker registry :
![image](https://user-images.githubusercontent.com/9356454/187641425-627cb3f4-13d3-42a1-9f45-b0f8390a0488.png)
- Prepare the hub pull secret to be updated with the new custom registry credentials:
![image](https://user-images.githubusercontent.com/9356454/187641605-ca079117-0abe-401e-b7b2-c5b917c8a6ad.png)
- Launch the ocp mirror step and try to download after that from the custom registry:
![image](https://user-images.githubusercontent.com/9356454/187641720-cf72b57c-d770-4a81-bd0b-8a7072dd3ff0.png)
![image](https://user-images.githubusercontent.com/9356454/187641260-85eba92f-1e78-4871-a1e3-69e30c8f3a4b.png)
At the end:
![image](https://user-images.githubusercontent.com/9356454/187644215-c9eee0a2-1d62-4667-8b8b-0ab40c5575c2.png)

### ** Test EDGE with External Registry**

First of all, as we're testing in the lab, we need to create the VM and edgecluster config yaml with the new registry url. To do that, we're creating this new Target in Makefile to do that, passing the REGISTRY as variable:
![image](https://user-images.githubusercontent.com/9356454/187866892-ea7aab7e-530e-45d6-8c50-19b1940b2ffc.png)
As you can see the new config yaml includes the REGISTRY entry:
![image](https://user-images.githubusercontent.com/9356454/187865396-db4b8b8e-c4e2-45f5-8c94-a3be2b2beddf.png)
After that, we could launch the pipeline as we're doing up to now:
![image](https://user-images.githubusercontent.com/9356454/187867129-efba15c5-5e7c-4e53-8043-6bcaf56a7ca4.png)

During the olm mirror in the lab using the same host we're experimenting issues with the disks (run out of space) so the step is not finished but the important step is covered as we see with the next logs:
![image](https://user-images.githubusercontent.com/9356454/187867378-da844c63-afea-4af7-9ca6-a1205fec4da3.png)
![image](https://user-images.githubusercontent.com/9356454/187867610-3290cad3-aee7-49d2-83ce-1dfddebe4371.png)

mirror ocp step: 
![image](https://user-images.githubusercontent.com/9356454/187867963-a1851b31-b421-42ec-8122-b5a6005a03bf.png)

Mirror olm step:
![image](https://user-images.githubusercontent.com/9356454/187868183-3bb7c37b-d1d0-4138-88cd-4233afa38c7a.png)
