### PR TITLE
wipe disks as a shared function

### DIFF
--- a/deploy-lso/deploy.sh
+++ b/deploy-lso/deploy.sh
@@ -55,35 +55,7 @@ if ! ./verify.sh; then
 
     index=0
     for edgecluster in ${ALLEDGECLUSTERS}; do
-        echo ">>>> Nuking storage disks for: ${edgecluster}"
-        echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-
-        cluster=$(yq eval ".edgeclusters[${index}]|keys" $EDGECLUSTERS_FILE | awk '{print $2}' | xargs echo)
-
-        for master in $(echo $(seq 0 $(($(yq eval ".edgeclusters[${index}].[]|keys" ${EDGECLUSTERS_FILE} | grep master | wc -l) - 1)))); do
-            EXT_MAC_ADDR=$(yq eval ".edgeclusters[${index}].[].master${master}.mac_ext_dhcp" ${EDGECLUSTERS_FILE})
-
-            recover_edgecluster_rsa ${cluster}
-
-            echo ""
-            echo ">>>> Nuking storage disks for Master ${master} Node"
-            for agent in $(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} agent -o name); do
-                NODE_IP=$(oc --kubeconfig=${KUBECONFIG_HUB} get -n ${cluster} ${agent} -o jsonpath="{.status.inventory.interfaces[?(@.macAddress==\"${EXT_MAC_ADDR}\")].ipV4Addresses[0]}")
-                if [[ -n ${NODE_IP} ]]; then
-                    echo "Master Node: ${master}"
-                    echo "AGENT: ${agent}"
-                    echo "IP: ${NODE_IP%%/*}"
-                    echo ">>>>"
-
-                    storage_disks=$(yq e ".edgeclusters[${index}].[].master${master}.storage_disk" $EDGECLUSTERS_FILE | awk '{print $2}' | xargs echo)
-
-                    for disk in ${storage_disks}; do
-                        echo ">>> Nuking disk ${disk} at ${master} ${NODE_IP%%/*}"
-                        ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "sudo sgdisk --zap-all $disk;sudo dd if=/dev/zero of=$disk bs=1M count=100 oflag=direct,dsync; sudo blkdiscard $disk"
-                    done
-                fi
-            done
-        done
+        wipe_edge_disks
 
         index=$((index + 1))
 

--- a/deploy-lvmo/deploy.sh
+++ b/deploy-lvmo/deploy.sh
@@ -55,6 +55,9 @@ if ! ./verify.sh; then
 
     index=0
     for edgecluster in ${ALLEDGECLUSTERS}; do
+        # wipe disks on nodes 
+        wipe_edge_disks
+
         NUM_M=$(yq e ".edgeclusters[${index}].[]|keys" ${EDGECLUSTERS_FILE} | grep master | wc -l | xargs)
 
         echo ">>>> Deploy manifests to install LSO and LocalVolume: ${edgecluster}"

--- a/deploy-lvmo/deploy.sh
+++ b/deploy-lvmo/deploy.sh
@@ -60,7 +60,7 @@ if ! ./verify.sh; then
 
         NUM_M=$(yq e ".edgeclusters[${index}].[]|keys" ${EDGECLUSTERS_FILE} | grep master | wc -l | xargs)
 
-        echo ">>>> Deploy manifests to install LSO and LocalVolume: ${edgecluster}"
+        echo ">>>> Deploy manifests to install LVMO: ${edgecluster}"
         echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
         echo "Extract Kubeconfig for ${edgecluster}"
         extract_kubeconfig_common ${edgecluster}


### PR DESCRIPTION
# Description

The deployment of LVMO operator in the SNO edgecluster require that the local disk are clean, hence it is mandatory to wipe the disks before install the operator and create the lvmcluster object.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Below is the output of the pipelie `deploy-pipeline-edgecluster-sno` , only the task deploy-lvmo where the disks are wiped before install the operator.

![image](https://user-images.githubusercontent.com/17329193/187726594-f33ed516-1e6b-4cf8-9f53-82248ab279d4.png)

