### PR TITLE
Mgmt 11881 fix deploy odf on sno edge

### DIFF
--- a/deploy-odf/deploy.sh
+++ b/deploy-odf/deploy.sh
@@ -122,6 +122,18 @@ if ! ./verify.sh; then
         fi
 	if [ "${NUM_M}" -eq "1" ];
 	then
+        echo ">>>> Waiting for: Backingstore"
+        echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+        timeout=0
+        ready=false
+        while [ "$timeout" -lt "1000" ]; do
+            if [[ $(oc get --kubeconfig=${EDGE_KUBECONFIG} -n openshift-storage backingstores.noobaa.io -ojsonpath='{.items[*].status.phase}') == "Ready" ]]; then
+            ready=true
+            break
+            fi
+            sleep 5
+            timeout=$((timeout + 1))
+        done
 		# By default the StorageCluster creates a Noobaa instances with a single volume of 50Gi for the
 		# pvPool. This is not enough for the mirror so we are increasing this number to 5
 		oc patch --kubeconfig=${EDGE_KUBECONFIG} -n openshift-storage BackingStore noobaa-default-backing-store --type json -p '[{"op": "add", "path": "/spec/pvPool/numVolumes", "value": 5}]'

--- a/shared-utils/common.sh
+++ b/shared-utils/common.sh
@@ -337,6 +337,7 @@ function wipe_edge_disks() {
                     echo ">>> Wipe disk ${disk} at ${master} ${NODE_IP%%/*}"
                     ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "sudo sgdisk --zap-all $disk;sudo dd if=/dev/zero of=$disk bs=1M count=100 oflag=direct,dsync; sudo blkdiscard $disk"
                 done
+                ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "dmsetup remove_all"
             fi
         done
     done    

--- a/shared-utils/common.sh
+++ b/shared-utils/common.sh
@@ -337,7 +337,10 @@ function wipe_edge_disks() {
                     echo ">>> Wipe disk ${disk} at ${master} ${NODE_IP%%/*}"
                     ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "sudo sgdisk --zap-all $disk;sudo dd if=/dev/zero of=$disk bs=1M count=100 oflag=direct,dsync; sudo blkdiscard $disk"
                 done
-                ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "dmsetup remove_all"
+                echo ">>>>"
+                echo "Remove all the existing VolumeGroups"
+                echo ">>>>"
+                ${SSH_COMMAND} -i ${RSA_KEY_FILE} core@${NODE_IP%%/*} "sudo dmsetup remove_all"
             fi
         done
     done    


### PR DESCRIPTION
# Description

There are a race condiction when the Nooba object is created on an SNO edgecluster.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing
Below is the output of the Tekton pipelinen `deploy-ztp-edgeclusters-sno`, only the part with the fix where it is waiting till the blockingstore.nooba.io object is created before apply the next patch.

file:///home/dchavero/Downloads/image%20(7).png
