### PR TITLE
Fix the issue with opm index prune.

### DIFF
--- a/deploy-disconnected-registry/olm-sync.sh
+++ b/deploy-disconnected-registry/olm-sync.sh
@@ -74,6 +74,7 @@ function mirror() {
     registry_login ${SOURCE_REGISTRY}
     echo ">>>> Podman Login into Destination Registry: ${DESTINATION_REGISTRY}"
     registry_login ${DESTINATION_REGISTRY}
+    [ -d ~/.docker ] || mkdir  ~/.docker
     cp -f ${PULL_SECRET} ~/.docker/config.json
 
     mkdir -p /var/run/user/0/containers


### PR DESCRIPTION
If the directory is missing the secret isn't copied to the right place and the opm index prune command fails.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
