### PR TITLE
Exit from workers task if no workers defined

### DIFF
--- a/deploy-worker/render_worker.sh
+++ b/deploy-worker/render_worker.sh
@@ -192,6 +192,16 @@ fi
 index=0
 
 for EDGE in ${ALLEDGECLUSTERS}; do
+    NUM_W=$(yq e ".edgeclusters[${index}].[]|keys" ${EDGECLUSTERS_FILE} | grep worker | wc -l | xargs)
+
+    # No need to proceed with this task
+    # if there are no workers
+    if [[ $NUM_W -eq 0 ]]; then
+        echo "No workers defined for cluster ${EDGE} in the configs... skipping"
+        index=$((index + 1))
+        continue
+    fi
+
     create_worker_definitions ${EDGE} ${index}
     for a in {1..10}; do
         WORKER_AGENT=$(oc --kubeconfig=${KUBECONFIG_HUB} get agent -n ${EDGE} --no-headers | grep worker | awk '{print $1}')


### PR DESCRIPTION
Skip `deploy-workers` for edgeclusters that don't have a worker defined.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update


**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
