### PR TITLE
Fix golangci-lint action working directory

### DIFF
--- a/.github/workflows/check-cli.yml
+++ b/.github/workflows/check-cli.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run the linter
-      working-directory: go
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.50.1
+        working-directory: go


### PR DESCRIPTION
# Description

The `golangci-lint` GitHub action isn't a _run_ action, so it doesn't accept the `working-directory` option, instead it has its own `working-directory` option inside the `with` section.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested by the GitHub action itself.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
