### PR TITLE
NO-ISSUE: Increase golangci-lint timeout

### DIFF
--- a/.github/workflows/check-cli.yml
+++ b/.github/workflows/check-cli.yml
@@ -64,3 +64,4 @@ jobs:
       with:
         working-directory: ztp
         version: v1.50.1
+        args: --timeout 5m


### PR DESCRIPTION
# Description

The `golangci-lint` GitHub action is frequently failing with an error message like this:

```
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
```

The default timeout is one minute. This patch increases the timeout to five minutes.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested in the GitHub action.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
