### PR TITLE
NO-ISSUE: Add testss for the `jq` object

### DIFF
--- a/ztp/internal/config.go
+++ b/ztp/internal/config.go
@@ -181,12 +181,12 @@ func (l *ConfigLoader) loadFromReader(reader io.Reader) (result map[string]any, 
 }
 
 func (l *ConfigLoader) loadProperties(content any, config *models.Config) error {
-	return l.jq.Run(`.config`, content, &config.Properties)
+	return l.jq.Query(`.config`, content, &config.Properties)
 }
 
 func (l *ConfigLoader) loadClusters(content any, config *models.Config) error {
 	var data []map[string]any
-	err := l.jq.Run(`.edgeclusters`, content, &data)
+	err := l.jq.Query(`.edgeclusters`, content, &data)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func (l *ConfigLoader) loadClusters(content any, config *models.Config) error {
 
 func (l *ConfigLoader) loadCluster(content any, cluster *models.Cluster) error {
 	var data map[string]any
-	err := l.jq.Run(`.`, content, &data)
+	err := l.jq.Query(`.`, content, &data)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func (l *ConfigLoader) loadCluster(content any, cluster *models.Cluster) error {
 
 func (l *ConfigLoader) loadClusterConfig(content any, cluster *models.Cluster) error {
 	var data configData
-	err := l.jq.Run(".", content, &data)
+	err := l.jq.Query(".", content, &data)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (l *ConfigLoader) loadClusterConfig(content any, cluster *models.Cluster) e
 
 func (l *ConfigLoader) loadNode(content any, node *models.Node) error {
 	var data nodeData
-	err := l.jq.Run(".", content, &data)
+	err := l.jq.Query(".", content, &data)
 	if err != nil {
 		return err
 	}

--- a/ztp/internal/jq.go
+++ b/ztp/internal/jq.go
@@ -62,10 +62,10 @@ func (b *JQBuilder) Build() (result *JQ, err error) {
 	return
 }
 
-// Run the given query on the given input data and stores the result into the given output variable.
-// An error will be returned if the query can't be parsed or if the data doesn't fit into the output
-// variable.
-func (j *JQ) Run(query string, input any, output any) error {
+// Query the given query on the given input data and stores the result into the given output
+// variable.  An error will be returned if the query can't be parsed or if the data doesn't fit into
+// the output variable.
+func (j *JQ) Query(query string, input any, output any) error {
 	// Check that the output is a pointer:
 	outputValue := reflect.ValueOf(output)
 	if outputValue.Kind() != reflect.Pointer {

--- a/ztp/internal/jq_test.go
+++ b/ztp/internal/jq_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package internal
+
+import (
+	"math"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JQ", func() {
+	var logger logr.Logger
+
+	BeforeEach(func() {
+		var err error
+		logger, err = NewLogger().
+			SetWriter(GinkgoWriter).
+			SetV(math.MaxInt).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can't be created without a logger", func() {
+		// Create the template:
+		jq, err := NewJQ().Build()
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("logger"))
+		Expect(msg).To(ContainSubstring("mandatory"))
+		Expect(jq).To(BeNil())
+	})
+
+	It("Accepts primitive input", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		var x int
+		err = jq.Query(`.`, 42, &x)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
+
+	It("Accepts struct input", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		type Point struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		}
+		p := &Point{
+			X: 42,
+			Y: 24,
+		}
+		var x int
+		err = jq.Query(`.x`, p, &x)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
+
+	It("Accepts map input", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		m := map[string]int{
+			"x": 42,
+			"y": 24,
+		}
+		var x int
+		err = jq.Query(`.x`, m, &x)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
+
+	It("Accepts slice input", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		s := []int{42, 24}
+		var x int
+		err = jq.Query(`.[0]`, s, &x)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
+
+	It("Gets all values if output is slice", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		s := []int{42, 24}
+		var t []int
+		err = jq.Query(`.[]`, s, &t)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(ConsistOf(42, 24))
+	})
+
+	It("Gets first value if there is only one and output is not slice", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		s := []int{42}
+		var x int
+		err = jq.Query(`.[]`, s, &x)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
+
+	It("Gets first value if there is only one and output is slice", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it accepts the input:
+		s := []int{42}
+		var t []int
+		err = jq.Query(`.[]`, s, &t)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(ConsistOf(42))
+	})
+
+	It("Fails if there are multiple results and output isn't slice", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it fails:
+		s := []int{42, 24}
+		var x int
+		err = jq.Query(`.[]`, s, &x)
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("cannot"))
+		Expect(msg).To(ContainSubstring("unmarshal"))
+		Expect(msg).To(ContainSubstring("int"))
+	})
+
+	It("Fails if output is not compatible with input", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it fails:
+		var x int
+		err = jq.Query(`.`, "mytext", &x)
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("cannot"))
+		Expect(msg).To(ContainSubstring("unmarshal"))
+		Expect(msg).To(ContainSubstring("int"))
+	})
+
+	It("Rejects output that isn't a pointer", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it rejects the ouptut:
+		var x int
+		err = jq.Query(`.`, 42, x)
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("pointer"))
+		Expect(msg).To(ContainSubstring("int"))
+	})
+})


### PR DESCRIPTION
# Description

This patch adds tests for the object that is used to run `jq` queries.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Run the new tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
