### PR TITLE
NO-ISSUE: Add support for creating CRDs and objects in testing env

### DIFF
--- a/ztp/internal/testing/environment/crds/0000_example.yaml
+++ b/ztp/internal/testing/environment/crds/0000_example.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This example shows how to create a CRD. Note the use of the `x-kubernetes-preserve-unknown-fields` 
+# annotation, that allows us to put anything inside the object without needing the complete
+# definition. In most cases this is fine because we don't want to validate these CRDs.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.example.com
+spec:
+  group: example.com
+  names:
+    kind: Example
+    listKind: ExampleList
+    plural: examples
+    singular: example
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/ztp/internal/testing/environment/objects/0000_example.yaml
+++ b/ztp/internal/testing/environment/objects/0000_example.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This example shows how to create an object.
+
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: example
+spec:
+  hello: world
+status:
+  all: good


### PR DESCRIPTION
# Description

This patch adds support for automatically creating CRDs and objects in the testing environment. The CRDs are defined with YAML files inside the `internal/testing/environment/crd` directory, and the objects with YAML files inside `internal/testing/environment/objects`. See the examples there.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
