### PR TITLE
NO-ISSUE: Add JQ methods to read from strings and bytes

### DIFF
--- a/ztp/internal/jq_test.go
+++ b/ztp/internal/jq_test.go
@@ -208,4 +208,46 @@ var _ = Describe("JQ", func() {
 		Expect(msg).To(ContainSubstring("pointer"))
 		Expect(msg).To(ContainSubstring("int"))
 	})
+
+	It("Can read from a string", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it can read from a string:
+		var x int
+		err = jq.QueryString(
+			`.x`,
+			`{
+				"x": 42,
+				"y": 24
+			}`,
+			&x,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
+
+	It("Can read from an array of bytes", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it can read from an array of bytes:
+		var x int
+		err = jq.QueryBytes(
+			`.x`,
+			[]byte(`{
+				"x": 42,
+				"y": 24
+			}`),
+			&x,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(x).To(Equal(42))
+	})
 })


### PR DESCRIPTION
# Description

This patch adds to the JQ object methods that read the input from strings or array of bytes.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
