### PR TITLE
NO-ISSUE: Add methods to get/set tool env

### DIFF
--- a/ztp/main.go
+++ b/ztp/main.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	// Create the tool:
 	tool, err := internal.NewTool().
-		AddEnv(os.Environ()...).
+		SetEnv(os.Environ()).
 		AddArgs(os.Args...).
 		SetIn(os.Stdin).
 		SetOut(os.Stdout).


### PR DESCRIPTION
# Description

This patch adds methods to get and set the environment variables of the tool. This is intended to simplify tests that use environment variables, as it will be much easier to prepare a fake set of environment variables.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
