### PR TITLE
NO-ISSUE: Move `TmpFS` to the testing package

### DIFF
--- a/ztp/internal/templating/engine_test.go
+++ b/ztp/internal/templating/engine_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
+	. "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/testing"
 )
 
 var _ = Describe("Engine", func() {

--- a/ztp/internal/templating/suite_test.go
+++ b/ztp/internal/templating/suite_test.go
@@ -15,10 +15,6 @@ License.
 package templating
 
 import (
-	"errors"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -28,50 +24,4 @@ import (
 func TestTemplating(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Templating")
-}
-
-// TmpFS creates a temporary directory containing the given files, and then creates a fs.FS object
-// that can be used to access it.
-//
-// The files are specified as pairs of full path names and content. For example, to create a file
-// named `mydir/myfile.yaml` containig some YAML text and a file `yourdir/yourfile.json` containing
-// some JSON text:
-//
-//	dir, fsys = TmpFS(
-//		"mydir/myfile.yaml",
-//		`
-//			name: Joe
-//			age: 52
-//		`,
-//		"yourdir/yourfile.json",
-//		`{
-//			"name": "Mary",
-//			"age": 59
-//		}`
-//	)
-//
-// Directories are created automatically when they contain at least one file or subdirectory.
-//
-// The caller is responsible for removing the directory once it is no longer needed.
-func TmpFS(args ...string) (dir string, fsys fs.FS) {
-	Expect(len(args) % 2).To(BeZero())
-	dir, err := os.MkdirTemp("", "*.testfs")
-	Expect(err).ToNot(HaveOccurred())
-	for i := 0; i < len(args)/2; i++ {
-		name := args[2*i]
-		text := args[2*i+1]
-		file := filepath.Join(dir, name)
-		sub := filepath.Dir(file)
-		_, err = os.Stat(sub)
-		if errors.Is(err, os.ErrNotExist) {
-			err = os.MkdirAll(sub, 0700)
-			Expect(err).ToNot(HaveOccurred())
-		} else {
-			Expect(err).ToNot(HaveOccurred())
-		}
-		err = os.WriteFile(file, []byte(text), 0600)
-		Expect(err).ToNot(HaveOccurred())
-	}
-	fsys = os.DirFS(dir)
-	return
 }

--- a/ztp/internal/testing/environment.go
+++ b/ztp/internal/testing/environment.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package internal
+package testing
 
 import (
 	"bufio"

--- a/ztp/internal/testing/environment_ca.go
+++ b/ztp/internal/testing/environment_ca.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package internal
+package testing
 
 import (
 	"crypto/rand"

--- a/ztp/internal/testing/fs.go
+++ b/ztp/internal/testing/fs.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package testing
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+)
+
+// TmpFS creates a temporary directory containing the given files, and then creates a fs.FS object
+// that can be used to access it.
+//
+// The files are specified as pairs of full path names and content. For example, to create a file
+// named `mydir/myfile.yaml` containig some YAML text and a file `yourdir/yourfile.json` containing
+// some JSON text:
+//
+//	dir, fsys = TmpFS(
+//		"mydir/myfile.yaml",
+//		`
+//			name: Joe
+//			age: 52
+//		`,
+//		"yourdir/yourfile.json",
+//		`{
+//			"name": "Mary",
+//			"age": 59
+//		}`
+//	)
+//
+// Directories are created automatically when they contain at least one file or subdirectory.
+//
+// The caller is responsible for removing the directory once it is no longer needed.
+func TmpFS(args ...string) (dir string, fsys fs.FS) {
+	Expect(len(args) % 2).To(BeZero())
+	dir, err := os.MkdirTemp("", "*.test")
+	Expect(err).ToNot(HaveOccurred())
+	for i := 0; i < len(args)/2; i++ {
+		name := args[2*i]
+		text := args[2*i+1]
+		file := filepath.Join(dir, name)
+		sub := filepath.Dir(file)
+		_, err = os.Stat(sub)
+		if errors.Is(err, os.ErrNotExist) {
+			err = os.MkdirAll(sub, 0700)
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+		err = os.WriteFile(file, []byte(text), 0600)
+		Expect(err).ToNot(HaveOccurred())
+	}
+	fsys = os.DirFS(dir)
+	return
+}


### PR DESCRIPTION
# Description

This patch moves the `TmpFS` function to the `testing` package, so that it can be used in other tests.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
