### PR TITLE
NO-ISSUE: Check existence of called template

### DIFF
--- a/ztp/internal/templating/engine.go
+++ b/ztp/internal/templating/engine.go
@@ -226,6 +226,10 @@ func (e *Engine) base64Func(value any) (result string, err error) {
 func (e *Engine) executeFunc(name string, data any) (result string, err error) {
 	buffer := &bytes.Buffer{}
 	executed := e.template.Lookup(name)
+	if executed == nil {
+		err = fmt.Errorf("failed to find template '%s'", name)
+		return
+	}
 	err = executed.Execute(buffer, data)
 	if err != nil {
 		return


### PR DESCRIPTION
# Description

Currently when a template uses the `execute` function to execute another template the code doesn't check if that template exists. The result is a nil pointer exception that is difficult to understand. This patch changes the code so that it checks that condition and generates an error message that is easier to understand.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Added a test.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
