### PR TITLE
NO-ISSUE: Support byte array as content of testing TmpFS

### DIFF
--- a/ztp/internal/testing/fs.go
+++ b/ztp/internal/testing/fs.go
@@ -46,12 +46,12 @@ import (
 // Directories are created automatically when they contain at least one file or subdirectory.
 //
 // The caller is responsible for removing the directory once it is no longer needed.
-func TmpFS(args ...string) (dir string, fsys fs.FS) {
+func TmpFS(args ...any) (dir string, fsys fs.FS) {
 	Expect(len(args) % 2).To(BeZero())
 	dir, err := os.MkdirTemp("", "*.test")
 	Expect(err).ToNot(HaveOccurred())
 	for i := 0; i < len(args)/2; i++ {
-		name := args[2*i]
+		name := args[2*i].(string)
 		text := args[2*i+1]
 		file := filepath.Join(dir, name)
 		sub := filepath.Dir(file)
@@ -62,7 +62,12 @@ func TmpFS(args ...string) (dir string, fsys fs.FS) {
 		} else {
 			Expect(err).ToNot(HaveOccurred())
 		}
-		err = os.WriteFile(file, []byte(text), 0600)
+		switch typed := text.(type) {
+		case string:
+			err = os.WriteFile(file, []byte(typed), 0600)
+		case []byte:
+			err = os.WriteFile(file, typed, 0600)
+		}
 		Expect(err).ToNot(HaveOccurred())
 	}
 	fsys = os.DirFS(dir)


### PR DESCRIPTION
# Description

Currently the content of the files passed to the `TmpFS` function need to be strings. That complicates passing values that are arrays of bytes. This patch changes the function so that it also accepts arrays bytes.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
