### PR TITLE
NO-ISSUE: Explicitly load kbueconfig in client

### DIFF
--- a/ztp/internal/client_test.go
+++ b/ztp/internal/client_test.go
@@ -18,14 +18,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
+	. "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/testing"
 )
 
 var _ = Describe("Client", func() {
@@ -71,6 +77,41 @@ var _ = Describe("Client", func() {
 		// Retrieve the list of pods:
 		list := &corev1.PodList{}
 		err = client.List(ctx, list)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Gets the configuration from the KUBECONFIG passed in the env", func() {
+		// Create a temporary directory for the configuration file:
+		dir, _ := TmpFS("my.config", kubeconfig)
+		defer func() {
+			err := os.RemoveAll(dir)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// Create the client:
+		client, err := NewClient().
+			SetLogger(logger).
+			SetEnv(map[string]string{
+				"KUBECONFIG": filepath.Join(dir, "my.config"),
+			}).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(client).ToNot(BeNil())
+
+		// Check that it can connect to the cluster. Note that we use the `example` CRD that
+		// we create only in the testing cluster to make sure that we are connecting to that
+		// cluster and not to any other that may be avaiable via the `~/.kube/config` file
+		// or via the real `KUBECONFIG` environment variable.
+		object := &unstructured.Unstructured{}
+		object.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "example.com",
+			Version: "v1",
+			Kind:    "Example",
+		})
+		key := clnt.ObjectKey{
+			Name: "example",
+		}
+		err = client.Get(ctx, key, object)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
# Description

Currently the Kubernetes API client loads the configuration using the `clientcmd` package. That in turn uses the `KUBECONFIG` environment variable. That complicates testing because it is difficult to change the values of the environment variables and then restore them after running the test. To make that simpler this patch changes the client builder so that it receives a map containing the environment, and uses those variables instead of `os.LookupEnv`.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
