### PR TITLE
NO-ISSUE: Add `--wait` option to `edgecluster`

### DIFF
--- a/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
+++ b/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
@@ -115,19 +115,9 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 func (c *Command) deleteCRDs(ctx context.Context) error {
 	// Find all the CRDs that we installed, so that we can then delete all the objects of those
 	// types:
-	selector, err := labels.Parse("ztp = true")
-	if err != nil {
-		return err
-	}
 	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "apiextensions.k8s.io",
-		Version: "v1",
-		Kind:    "CustomResourceDefinition",
-	})
-	err = c.client.List(ctx, list, &clnt.ListOptions{
-		LabelSelector: selector,
-	})
+	list.SetGroupVersionKind(internal.CustomResourceDefinitionListGVK)
+	err := c.client.List(ctx, list, clnt.MatchingLabels{"ztp": "true"})
 	if err != nil {
 		return err
 	}
@@ -245,14 +235,8 @@ func (c *Command) deleteObject(ctx context.Context, object *unstructured.Unstruc
 
 func (c *Command) deleteNamespaces(ctx context.Context) error {
 	// Find and all the namespaces that we created:
-	nsSelector, err := labels.Parse("ztp = true")
-	if err != nil {
-		return err
-	}
 	nsList := &corev1.NamespaceList{}
-	err = c.client.List(ctx, nsList, &clnt.ListOptions{
-		LabelSelector: nsSelector,
-	})
+	err := c.client.List(ctx, nsList, clnt.MatchingLabels{"ztp": "true"})
 	if err != nil {
 		return err
 	}

--- a/ztp/internal/cmd/edgecluster_cmd_test.go
+++ b/ztp/internal/cmd/edgecluster_cmd_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
@@ -110,7 +109,7 @@ var _ = Describe("'edgecluster' command", func() {
 			// Run the command:
 			tool, err := internal.NewTool().
 				SetLogger(logger).
-				AddArgs("oc-ztp", "edgecluster").
+				AddArgs("ztp", "edgecluster", "--wait=0").
 				AddCommand(edgeclustercmd.Cobra).
 				SetEnv(env).
 				SetIn(&bytes.Buffer{}).
@@ -118,7 +117,7 @@ var _ = Describe("'edgecluster' command", func() {
 				SetErr(GinkgoWriter).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			err = tool.Run()
+			err = tool.Run(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Create the API client:
@@ -165,11 +164,7 @@ var _ = Describe("'edgecluster' command", func() {
 
 		It("Creates the agent cluster install", func() {
 			object := &unstructured.Unstructured{}
-			object.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "extensions.hive.openshift.io",
-				Version: "v1beta1",
-				Kind:    "AgentClusterInstall",
-			})
+			object.SetGroupVersionKind(internal.AgentClusterIntallGVK)
 			key := clnt.ObjectKey{
 				Namespace: "edgecluster0-cluster",
 				Name:      "edgecluster0-cluster",
@@ -180,11 +175,7 @@ var _ = Describe("'edgecluster' command", func() {
 
 		It("Creates the cluster deployment", func() {
 			object := &unstructured.Unstructured{}
-			object.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "hive.openshift.io",
-				Version: "v1",
-				Kind:    "ClusterDeployment",
-			})
+			object.SetGroupVersionKind(internal.ClusterDeploymentGVK)
 			key := clnt.ObjectKey{
 				Namespace: "edgecluster0-cluster",
 				Name:      "edgecluster0-cluster",
@@ -195,11 +186,7 @@ var _ = Describe("'edgecluster' command", func() {
 
 		It("Creates the managed cluster", func() {
 			object := &unstructured.Unstructured{}
-			object.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "cluster.open-cluster-management.io",
-				Version: "v1",
-				Kind:    "ManagedCluster",
-			})
+			object.SetGroupVersionKind(internal.ManagedClusterGVK)
 			key := clnt.ObjectKey{
 				Name: "edgecluster0-cluster",
 			}
@@ -209,11 +196,7 @@ var _ = Describe("'edgecluster' command", func() {
 
 		It("Creates the infrastructure environment", func() {
 			object := &unstructured.Unstructured{}
-			object.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "agent-install.openshift.io",
-				Version: "v1beta1",
-				Kind:    "InfraEnv",
-			})
+			object.SetGroupVersionKind(internal.InfraEnvGKV)
 			key := clnt.ObjectKey{
 				Namespace: "edgecluster0-cluster",
 				Name:      "edgecluster0-cluster",
@@ -224,11 +207,7 @@ var _ = Describe("'edgecluster' command", func() {
 
 		It("Creates the `nmstate` configuration environment", func() {
 			object := &unstructured.Unstructured{}
-			object.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "agent-install.openshift.io",
-				Version: "v1beta1",
-				Kind:    "NMStateConfig",
-			})
+			object.SetGroupVersionKind(internal.NMStateConfigGVK)
 			key := clnt.ObjectKey{
 				Namespace: "edgecluster0-cluster",
 				Name:      "ztpfw-edgecluster0-cluster-master-master0",
@@ -249,11 +228,7 @@ var _ = Describe("'edgecluster' command", func() {
 
 		It("Creates the bare metal host", func() {
 			object := &unstructured.Unstructured{}
-			object.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "metal3.io",
-				Version: "v1alpha1",
-				Kind:    "BareMetalHost",
-			})
+			object.SetGroupVersionKind(internal.BareMetalHostGVK)
 			key := clnt.ObjectKey{
 				Namespace: "edgecluster0-cluster",
 				Name:      "ztpfw-edgecluster0-cluster-master-master0",
@@ -286,7 +261,7 @@ var _ = Describe("'edgecluster' command", func() {
 			// Run the command again:
 			tool, err := internal.NewTool().
 				SetLogger(logger).
-				AddArgs("oc-ztp", "edgecluster").
+				AddArgs("ztp", "edgecluster", "--wait=0").
 				AddCommand(edgeclustercmd.Cobra).
 				SetEnv(env).
 				SetIn(&bytes.Buffer{}).
@@ -294,7 +269,7 @@ var _ = Describe("'edgecluster' command", func() {
 				SetErr(GinkgoWriter).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			err = tool.Run()
+			err = tool.Run(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the object has been created:

--- a/ztp/internal/cmd/version_cmd_test.go
+++ b/ztp/internal/cmd/version_cmd_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
@@ -25,6 +26,12 @@ import (
 )
 
 var _ = Describe("'version' command", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
 	It("Prints the build commit", func() {
 		// Prepare buffers to capture the output:
 		inBuffer := &bytes.Buffer{}
@@ -40,7 +47,7 @@ var _ = Describe("'version' command", func() {
 			SetErr(errBuffer).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-		err = tool.Run()
+		err = tool.Run(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check the otuput. Note that we expect unknown commit and time because the test

--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -29,7 +29,6 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
@@ -219,11 +218,7 @@ func (c *Enricher) setDNSDomain(ctx context.Context, cluster *models.Cluster) er
 
 func (c *Enricher) getDNSDomain(ctx context.Context) (result string, err error) {
 	object := &unstructured.Unstructured{}
-	object.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "operator.openshift.io",
-		Version: "v1",
-		Kind:    "IngressController",
-	})
+	object.SetGroupVersionKind(IngressControllerGVK)
 	key := clnt.ObjectKey{
 		Namespace: "openshift-ingress-operator",
 		Name:      "default",

--- a/ztp/internal/errors.go
+++ b/ztp/internal/errors.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package internal
+
+import "fmt"
+
+// ExitError is an error type that contains a process exit code. This is itended for situations
+// where you want to call os.Exit only in one place, but also want some deeply nested functions to
+// decide what should be the exit code.
+type ExitError int
+
+// Error is the implementation of the error interface.
+func (e ExitError) Error() string {
+	return fmt.Sprintf("%d", e)
+}
+
+// Code returns the exit code.
+func (e ExitError) Code() int {
+	return int(e)
+}

--- a/ztp/internal/gvks.go
+++ b/ztp/internal/gvks.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package internal
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// This file contains constants for some GroupVersionKinds that are used frequently in the project.
+
+var (
+	AgentClusterIntallGVK = schema.GroupVersionKind{
+		Group:   "extensions.hive.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentClusterInstall",
+	}
+	AgentClusterIntallListGVK = listGVK(AgentClusterIntallGVK)
+
+	BareMetalHostGVK = schema.GroupVersionKind{
+		Group:   "metal3.io",
+		Version: "v1alpha1",
+		Kind:    "BareMetalHost",
+	}
+	BareMetalHostListGVK = listGVK(BareMetalHostGVK)
+
+	ClusterDeploymentGVK = schema.GroupVersionKind{
+		Group:   "hive.openshift.io",
+		Version: "v1",
+		Kind:    "ClusterDeployment",
+	}
+	ClusterDeploymentListGVK = listGVK(ClusterDeploymentGVK)
+
+	CustomResourceDefinitionGVK = schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	}
+	CustomResourceDefinitionListGVK = listGVK(CustomResourceDefinitionGVK)
+
+	InfraEnvGKV = schema.GroupVersionKind{
+		Group:   "agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "InfraEnv",
+	}
+	InfraEnvListGKV = listGVK(InfraEnvGKV)
+
+	IngressControllerGVK = schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "IngressController",
+	}
+	IngressControllerListGVK = listGVK(IngressControllerGVK)
+
+	ManagedClusterGVK = schema.GroupVersionKind{
+		Group:   "cluster.open-cluster-management.io",
+		Version: "v1",
+		Kind:    "ManagedCluster",
+	}
+	ManagedClusterListGVK = listGVK(ManagedClusterGVK)
+
+	NMStateConfigGVK = schema.GroupVersionKind{
+		Group:   "agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "NMStateConfig",
+	}
+	NMStateConfigListGVK = listGVK(NMStateConfigGVK)
+)
+
+func listGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
+	gvk.Kind = gvk.Kind + "List"
+	return gvk
+}

--- a/ztp/internal/logging/logger.go
+++ b/ztp/internal/logging/logger.go
@@ -96,6 +96,11 @@ func (b *LoggerBuilder) Build() (result logr.Logger, err error) {
 
 	// Create the logr logger:
 	result = zapr.NewLoggerWithOptions(logger, zapr.LogInfoLevel("v"))
+
+	// Add the the PID so that it will be easy to identify the process when there are multiple
+	// processes writing to the same log file:
+	result = result.WithValues("pid", os.Getpid())
+
 	return
 }
 

--- a/ztp/main.go
+++ b/ztp/main.go
@@ -15,6 +15,7 @@ License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -25,6 +26,9 @@ import (
 )
 
 func main() {
+	// Create a context:
+	ctx := context.Background()
+
 	// Create the tool:
 	tool, err := internal.NewTool().
 		SetEnv(os.Environ()).
@@ -42,9 +46,14 @@ func main() {
 	}
 
 	// Run the tool:
-	err = tool.Run()
+	err = tool.Run(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
-		os.Exit(1)
+		exitErr, ok := err.(internal.ExitError)
+		if ok {
+			os.Exit(exitErr.Code())
+		} else {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
# Description

This patch adds the `--wait` option to the `edgecluster` command. This option tells the command how long to wait till the clusters are ready. The default is one hour. Setting it to zero means that the command will not wait at all.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
