### PR TITLE
NO-ISSUE: Fix command package names

### DIFF
--- a/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
+++ b/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package cmd
+package cleanup
 
 import (
 	"context"

--- a/ztp/internal/cmd/dev/dev_cmd.go
+++ b/ztp/internal/cmd/dev/dev_cmd.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package cmd
+package dev
 
 import (
 	"github.com/spf13/cobra"

--- a/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
+++ b/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package cmd
+package setup
 
 import (
 	"context"

--- a/ztp/internal/cmd/version/version_cmd.go
+++ b/ztp/internal/cmd/version/version_cmd.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package cmd
+package version
 
 import (
 	"fmt"


### PR DESCRIPTION
# Description

The files in the `cmd/...` packages have all `cmd` as package name. That doesn't have any real impact, but it is wrong. This patch fixes thos package names.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
