### PR TITLE
NO-ISSUE: Fix indentation of `worker0` in doc

### DIFF
--- a/documentation/ztp-for-factories/ztp-for-factory-edgeclusters-yaml.adoc
+++ b/documentation/ztp-for-factories/ztp-for-factory-edgeclusters-yaml.adoc
@@ -47,7 +47,7 @@ xref:edgeclusters[edgeclusters]:
           - /dev/sdc
           - /dev/sde
           - /dev/sdd
-    xref:workername[worker0]:
+      xref:workername[worker0]:
         xref:nic_ext_dhcp[nic_ext_dhcp]: eno4
         xref:mac_ext_dhcp[mac_ext_dhcp]: "aa:ss:dd:ee:b0:19"
         xref:bmc_url[bmc_url]: "<url bmc>"


### PR DESCRIPTION
# Description

The `worker0` section of the documented example is indented incorrectly. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

## Testing

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
