### PR TITLE
NO-ISSUE: Calculate OCP versions

### DIFF
--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -22,8 +22,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
+	"regexp"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/crypto/ssh"
@@ -111,9 +114,143 @@ func (b *EnricherBuilder) Build() (result *Enricher, err error) {
 	return
 }
 
-// Enrich completes the description of the given cluster adding the information that will be later
-// required to create it.
-func (e *Enricher) Enrich(ctx context.Context, cluster *models.Cluster) error {
+// Enrich completes the configuration adding the information that will be required later to create
+// the clusters.
+func (e *Enricher) Enrich(ctx context.Context, config *models.Config) error {
+	err := e.enrichProperties(ctx, config.Properties)
+	if err != nil {
+		return err
+	}
+	for i := range config.Clusters {
+		err := e.enrichCluster(ctx, &config.Clusters[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Enricher) enrichProperties(ctx context.Context, properties map[string]string) error {
+	setters := []func(context.Context, map[string]string) error{
+		e.setOCPTag,
+		e.setRHCOSRelease,
+	}
+	for _, setter := range setters {
+		err := setter(ctx, properties)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Enricher) setOCPTag(ctx context.Context, properties map[string]string) error {
+	// Do nothing if already set:
+	ocpTag := properties[models.OCPTagProperty]
+	if ocpTag != "" {
+		return nil
+	}
+
+	// Check that the version has been specified:
+	ocpVersion := properties[models.OCPVersionProperty]
+	if ocpVersion == "" {
+		return fmt.Errorf(
+			"failed to set OCP tag because property '%s' hasn't been specified",
+			models.OCPVersionProperty,
+		)
+	}
+
+	// Calculate the tag:
+	ocpTag = fmt.Sprintf("%s-x86_64", ocpVersion)
+
+	// Update the properties:
+	properties[models.OCPTagProperty] = ocpTag
+	e.logger.V(2).Info(
+		"Set OCP tag property",
+		"name", models.OCPTagProperty,
+		"value", ocpTag,
+	)
+	return nil
+}
+
+func (e *Enricher) setRHCOSRelease(ctx context.Context, properties map[string]string) error {
+	// Do nothing if it is already set:
+	rhcosRelease := properties[models.OCPRCHOSReleaseProperty]
+	if rhcosRelease != "" {
+		return nil
+	}
+
+	// Check that the version has been specified:
+	ocpVersion := properties[models.OCPVersionProperty]
+	if ocpVersion == "" {
+		return fmt.Errorf(
+			"failed to set RHCOS release because property '%s' hasn't been specified",
+			models.OCPVersionProperty,
+		)
+	}
+
+	// Download the `release.txt` file:
+	releaseTXT, err := e.downloadReleaseTXT(ctx, properties)
+	if err != nil {
+		return err
+	}
+
+	// Extract the RHCOS release:
+	rhcosReleaseMatches := enricherRHCOSReleaseRE.FindStringSubmatch(string(releaseTXT))
+	if len(rhcosReleaseMatches) < 2 {
+		return fmt.Errorf("failed to find RHCOS release inside 'release.txt' file")
+	}
+	rchosRelease := rhcosReleaseMatches[1]
+
+	// Update the properties:
+	properties[models.OCPRCHOSReleaseProperty] = rchosRelease
+	e.logger.Info(
+		"Set RHCOS release property",
+		"name", models.OCPRCHOSReleaseProperty,
+		"value", rchosRelease,
+	)
+
+	return nil
+}
+
+func (e *Enricher) downloadReleaseTXT(ctx context.Context, properties map[string]string) (result string,
+	err error) {
+	mirror := properties[models.OCPMirrorProperty]
+	if mirror == "" {
+		mirror = enricherDefaultMirror
+	}
+	version := properties[models.OCPVersionProperty]
+	url := fmt.Sprintf(
+		"%s/%s/release.txt",
+		mirror, version,
+	)
+	response, err := http.Get(url)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		err = fmt.Errorf(
+			"failed to download 'release.txt' file from URL '%s' because server "+
+				"responded with status code %d",
+			url, response.StatusCode,
+		)
+		return
+	}
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+	result = string(data)
+	e.logger.V(2).Info(
+		"Downloaded 'release.txt' file",
+		"url", url,
+		"text", result,
+	)
+	return
+}
+
+func (e *Enricher) enrichCluster(ctx context.Context, cluster *models.Cluster) error {
 	setters := []func(context.Context, *models.Cluster) error{
 		e.setSNO,
 		e.setPullSecret,
@@ -129,7 +266,6 @@ func (e *Enricher) Enrich(ctx context.Context, cluster *models.Cluster) error {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -292,4 +428,22 @@ const (
 	hardcodedClusterNetworkCIDR       = "10.128.0.0/14"
 	hardcodedMachineNetworkCIDR       = "192.168.7.0/24"
 	hardcodedServiceNetworkCIDR       = "172.30.0.0/16"
+)
+
+// enricherDefaultMirror is the debault base URL for downloading the `release.txt` files, used when
+// the `OC_OCP_MIRROR` property isn't set.
+const enricherDefaultMirror = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+
+// enricherRHCOSReleaseRE is the regular expressions used by the enricher to extract the RHCOS
+// release number for the OpenShift `release.txt` file. For example, if the file contains a line
+// line this:
+//
+//	Component Versions:
+//
+//	  kubernetes 1.23.12
+//	  machine-os 410.84.202210130022-0 Red Hat Enterprise Linux CoreOS
+//
+// It will extract the value `410.84.202210130022-0`.
+var enricherRHCOSReleaseRE = regexp.MustCompile(
+	`(?m:^\s*machine-os\s+(.*)\s+Red\s+Hat\s+Enterprise\s+Linux\s+CoreOS\s*$)`,
 )

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -17,15 +17,18 @@ package internal
 import (
 	"context"
 	"math"
+	"net/http"
 	"os"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
+	. "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/testing"
 )
 
 var _ = Describe("Enricher", func() {
@@ -55,29 +58,31 @@ var _ = Describe("Enricher", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Can't be created without a logger", func() {
-		enricher, err := NewEnricher().
-			SetClient(client).
-			Build()
-		Expect(err).To(HaveOccurred())
-		msg := err.Error()
-		Expect(msg).To(ContainSubstring("logger"))
-		Expect(msg).To(ContainSubstring("mandatory"))
-		Expect(enricher).To(BeNil())
+	Context("Creation", func() {
+		It("Can't be created without a logger", func() {
+			enricher, err := NewEnricher().
+				SetClient(client).
+				Build()
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("logger"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+			Expect(enricher).To(BeNil())
+		})
+
+		It("Can't be created without a Kubernetes API client", func() {
+			enricher, err := NewEnricher().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("client"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+			Expect(enricher).To(BeNil())
+		})
 	})
 
-	It("Can't be created without a Kubernetes API client", func() {
-		enricher, err := NewEnricher().
-			SetLogger(logger).
-			Build()
-		Expect(err).To(HaveOccurred())
-		msg := err.Error()
-		Expect(msg).To(ContainSubstring("client"))
-		Expect(msg).To(ContainSubstring("mandatory"))
-		Expect(enricher).To(BeNil())
-	})
-
-	Context("Already created", func() {
+	Context("Usage", func() {
 		var (
 			defaultPullSecretData []byte
 			defaultPullSecretFile string
@@ -136,51 +141,65 @@ var _ = Describe("Enricher", func() {
 		})
 
 		It("Sets the SNO flag to true when there is only one control plane node", func() {
-			// Create the cluster:
-			cluster := &models.Cluster{
-				Name: "my-cluster",
-				Nodes: []models.Node{
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node",
-					},
+			// Create the config:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
 				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
 			}
 
-			// Enrich the cluster:
-			err := enricher.Enrich(ctx, cluster)
+			// Enrich the config:
+			err := enricher.Enrich(ctx, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the flag has been set:
-			Expect(cluster.SNO).To(BeTrue())
+			Expect(config.Clusters[0].SNO).To(BeTrue())
 		})
 
 		It("Sets the SNO flag to false when there are three control plane nodes", func() {
-			// Create the cluster:
-			cluster := &models.Cluster{
-				Name: "my-cluster",
-				Nodes: []models.Node{
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node-0",
-					},
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node-1",
-					},
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node-2",
-					},
+			// Create the config:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
 				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node-0",
+						},
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node-1",
+						},
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node-2",
+						},
+					},
+				}},
 			}
 
-			// Enrich the cluster:
-			err := enricher.Enrich(ctx, cluster)
+			// Enrich the config:
+			err := enricher.Enrich(ctx, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the flag has been set:
-			Expect(cluster.SNO).To(BeFalse())
+			Expect(config.Clusters[0].SNO).To(BeFalse())
 		})
 
 		It("Doesn't change the pull secret if already set", func() {
@@ -194,87 +213,253 @@ var _ = Describe("Enricher", func() {
 				}
 			}`)
 
-			// Create the cluster with that pull secret:
-			cluster := &models.Cluster{
-				Name:       "my-cluster",
-				PullSecret: customPullSecretData,
-				Nodes: []models.Node{
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node",
-					},
+			// Create the config with that pull secret:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
 				},
+				Clusters: []models.Cluster{{
+					Name:       "my-cluster",
+					PullSecret: customPullSecretData,
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
 			}
 
-			// Enrich the cluster:
-			err := enricher.Enrich(ctx, cluster)
+			// Enrich the config:
+			err := enricher.Enrich(ctx, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the pull secret hasn't changed:
-			Expect(cluster.PullSecret).To(Equal(customPullSecretData))
+			Expect(config.Clusters[0].PullSecret).To(Equal(customPullSecretData))
 		})
 
 		It("Gets the pull secret from the environment variable", func() {
-			// Create the cluster without a pull secret:
-			cluster := &models.Cluster{
-				Name: "my-cluster",
-				Nodes: []models.Node{
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node",
-					},
+			// Create the config without a pull secret:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
 				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
 			}
 
-			// Enrich the cluster:
-			err := enricher.Enrich(ctx, cluster)
+			// Enrich the config:
+			err := enricher.Enrich(ctx, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the pull secret has been set:
-			Expect(cluster.PullSecret).To(Equal(defaultPullSecretData))
+			Expect(config.Clusters[0].PullSecret).To(Equal(defaultPullSecretData))
 		})
 
 		It("Doesn't change the DNS domain if already set", func() {
 			// Create the cluster:
-			cluster := &models.Cluster{
-				Name: "my-cluster",
-				DNS: models.DNS{
-					Domain: "example.net",
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
 				},
-				Nodes: []models.Node{
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node",
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					DNS: models.DNS{
+						Domain: "example.net",
 					},
-				},
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
 			}
 
-			// Enrich the cluster:
-			err := enricher.Enrich(ctx, cluster)
+			// Enrich the config:
+			err := enricher.Enrich(ctx, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the flag has been set:
-			Expect(cluster.DNS.Domain).To(Equal("example.net"))
+			Expect(config.Clusters[0].DNS.Domain).To(Equal("example.net"))
 		})
 
 		It("Gets the DNS domain from the default ingress controller of the hub", func() {
-			// Create the cluster:
-			cluster := &models.Cluster{
-				Name: "my-cluster",
-				Nodes: []models.Node{
-					{
-						Kind: models.NodeKindControlPlane,
-						Name: "my-node",
-					},
+			// Create the config:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
 				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
 			}
 
-			// Enrich the cluster:
-			err := enricher.Enrich(ctx, cluster)
+			// Enrich the config:
+			err := enricher.Enrich(ctx, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the flag has been set:
-			Expect(cluster.DNS.Domain).To(Equal("example.com"))
+			Expect(config.Clusters[0].DNS.Domain).To(Equal("example.com"))
+		})
+
+		It("Fails if the OCP version property isn't set", func() {
+			config := &models.Config{}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("OC_OCP_VERSION"))
+		})
+
+		It("Doesn't change OCP tag if already set", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "my-tag",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
+				},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Properties).To(HaveKeyWithValue("OC_OCP_TAG", "my-tag"))
+		})
+
+		It("Calculates the OCP tag if not set", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
+				},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Properties).To(HaveKeyWithValue("OC_OCP_TAG", "4.10.38-x86_64"))
+		})
+
+		It("Doesn't change the RHCOS release if already set", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "my-release",
+				},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Properties).To(HaveKeyWithValue("OC_RHCOS_RELEASE", "my-release"))
+		})
+
+		It("Doesn't change the RHCOS release if already set", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "my-release",
+				},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Properties).To(HaveKeyWithValue(
+				"OC_RHCOS_RELEASE", "my-release",
+			))
+		})
+
+		It("Extracts the RHCOS release from the `release.txt` file", func() {
+			// Prepare the mirror server:
+			server := NewServer()
+			defer server.Close()
+			server.AppendHandlers(RespondWith(
+				http.StatusOK,
+				Dedent(`
+					Component Versions:
+					  kubernetes 1.23.12               
+					  machine-os my-release Red Hat Enterprise Linux CoreOS
+				`),
+			))
+
+			// Create the enricher:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION": "4.10.38",
+					"OC_OCP_TAG":     "4.10.38-x86_64",
+					"OC_OCP_MIRROR":  server.URL(),
+				},
+			}
+
+			// Check that it gets the release returned by the server:
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Properties).To(HaveKeyWithValue(
+				"OC_RHCOS_RELEASE", "my-release",
+			))
+		})
+
+		It("Fails if the mirror responds with an error", func() {
+			// Prepare the mirror server:
+			server := NewServer()
+			defer server.Close()
+			server.AppendHandlers(RespondWith(http.StatusNotFound, nil))
+
+			// Create the enricher:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION": "4.10.38",
+					"OC_OCP_TAG":     "4.10.38-x86_64",
+					"OC_OCP_MIRROR":  server.URL(),
+				},
+			}
+
+			// Check that it fails:
+			err := enricher.Enrich(ctx, config)
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("release.txt"))
+			Expect(msg).To(ContainSubstring(server.URL()))
+			Expect(msg).To(ContainSubstring("404"))
+		})
+
+		It("Fails if the `release.txt` file doesn't contain the expected text", func() {
+			// Prepare the mirror server:
+			server := NewServer()
+			defer server.Close()
+			server.AppendHandlers(RespondWith(http.StatusOK, "junk"))
+
+			// Create the enricher:
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION": "4.10.38",
+					"OC_OCP_TAG":     "4.10.38-x86_64",
+					"OC_OCP_MIRROR":  server.URL(),
+				},
+			}
+
+			// Check that it fails:
+			err := enricher.Enrich(ctx, config)
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("find RHCOS release"))
+			Expect(msg).To(ContainSubstring("release.txt"))
 		})
 	})
 })

--- a/ztp/internal/models/properties.go
+++ b/ztp/internal/models/properties.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package models
+
+// This file contains constants for names of commonly used configuration properties:
+
+// OCPVersionProperty is the name of the property used to define the OpenShift version to be used
+// for the installation of clusters.
+const OCPVersionProperty = "OC_OCP_VERSION"
+
+// OCPTagProperty is the image tag of the OpenShift version. If not specified then the tag will be
+// calculated adding the `-x86_64` suffix. For example, of the value of `OC_OCP_VERSION` is
+// `4.10.38` then the value of this will be `4.10.38-x86_64`.
+const OCPTagProperty = "OC_OCP_TAG"
+
+// OCPRCHOSReleaseProperty is the full release number of the Red Hat Enterprise Linux CoreOS to be
+// used for the installation of clusters. If not specified this will be extracted from the
+// `release.txt` file corresponding to the version specified in `OC_OCP_VERSION`.
+const OCPRCHOSReleaseProperty = "OC_RHCOS_RELEASE"
+
+// OCPMirrorProperty is the base URL for the OCP mirror that will be used to download the
+// `release.txt` file. The default is to use `https://mirror.openshift.com/pub/openshift-v4/clients/ocp/`
+// and there is usually no need to change it. This is only intended for use in unit tests.
+const OCPMirrorProperty = "OC_OCP_MIRROR"


### PR DESCRIPTION
# Description

This patch changes the enricher so that it calculates default values for the `OC_OCP_TAG` and `OC_RCHOS_RELEASE` properties.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
