### PR TITLE
NO-ISSUE: Rename `edgecluster` to `create cluster`

### DIFF
--- a/ztp/go.mod
+++ b/ztp/go.mod
@@ -60,7 +60,7 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -12,7 +12,7 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package edgecluster
+package cluster
 
 import (
 	"context"
@@ -30,14 +30,15 @@ import (
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
 )
 
-// Cobra creates and returns the `edgecluster` command.
+// Cobra creates and returns the `create cluster` command.
 func Cobra() *cobra.Command {
 	c := NewCommand()
 	result := &cobra.Command{
-		Use:   "edgecluster",
-		Short: "Creates an edge cluster",
-		Args:  cobra.NoArgs,
-		RunE:  c.Run,
+		Use:     "cluster",
+		Aliases: []string{"clusters"},
+		Short:   "Creates clusters",
+		Args:    cobra.NoArgs,
+		RunE:    c.Run,
 	}
 	flags := result.Flags()
 	flags.StringVar(
@@ -56,7 +57,7 @@ func Cobra() *cobra.Command {
 	return result
 }
 
-// Command contains the data and logic needed to run the `edgecluster` command.
+// Command contains the data and logic needed to run the `create cluster` command.
 type Command struct {
 	flags struct {
 		config string
@@ -71,12 +72,12 @@ type Command struct {
 	applier *internal.Applier
 }
 
-// NewCommand creates a new runner that knows how to execute the `edgecluster` command.
+// NewCommand creates a new runner that knows how to execute the `create cluster` command.
 func NewCommand() *Command {
 	return &Command{}
 }
 
-// Run runs the `edgecluster` command.
+// Run runs the `create cluster` command.
 func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	var err error
 

--- a/ztp/internal/cmd/create/create_cmd.go
+++ b/ztp/internal/cmd/create/create_cmd.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	createclustercmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create/cluster"
+)
+
+// Cobra creates and returns the `create` command.
+func Cobra() *cobra.Command {
+	result := &cobra.Command{
+		Use:   "create",
+		Short: "Creates objects",
+		Args:  cobra.NoArgs,
+	}
+	result.AddCommand(createclustercmd.Cobra())
+	return result
+}

--- a/ztp/internal/cmd/create_cluster_cmd_test.go
+++ b/ztp/internal/cmd/create_cluster_cmd_test.go
@@ -30,12 +30,12 @@ import (
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
-	edgeclustercmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/edgecluster"
+	createcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create"
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
 	. "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/testing"
 )
 
-var _ = Describe("'edgecluster' command", func() {
+var _ = Describe("Create cluster command", func() {
 	var (
 		ctx    context.Context
 		logger logr.Logger
@@ -109,8 +109,8 @@ var _ = Describe("'edgecluster' command", func() {
 			// Run the command:
 			tool, err := internal.NewTool().
 				SetLogger(logger).
-				AddArgs("ztp", "edgecluster", "--wait=0").
-				AddCommand(edgeclustercmd.Cobra).
+				AddArgs("ztp", "create", "cluster", "--wait=0").
+				AddCommand(createcmd.Cobra).
 				SetEnv(env).
 				SetIn(&bytes.Buffer{}).
 				SetOut(GinkgoWriter).
@@ -261,8 +261,8 @@ var _ = Describe("'edgecluster' command", func() {
 			// Run the command again:
 			tool, err := internal.NewTool().
 				SetLogger(logger).
-				AddArgs("ztp", "edgecluster", "--wait=0").
-				AddCommand(edgeclustercmd.Cobra).
+				AddArgs("ztp", "create", "cluster", "--wait=0").
+				AddCommand(createcmd.Cobra).
 				SetEnv(env).
 				SetIn(&bytes.Buffer{}).
 				SetOut(GinkgoWriter).

--- a/ztp/internal/cmd/version_cmd_test.go
+++ b/ztp/internal/cmd/version_cmd_test.go
@@ -25,7 +25,7 @@ import (
 	versioncmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/version"
 )
 
-var _ = Describe("'version' command", func() {
+var _ = Describe("Version command", func() {
 	var ctx context.Context
 
 	BeforeEach(func() {

--- a/ztp/main.go
+++ b/ztp/main.go
@@ -20,8 +20,8 @@ import (
 	"os"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	createcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create"
 	devcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/dev"
-	edgeclustercmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/edgecluster"
 	versioncmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/version"
 )
 
@@ -36,8 +36,8 @@ func main() {
 		SetIn(os.Stdin).
 		SetOut(os.Stdout).
 		SetErr(os.Stderr).
+		AddCommand(createcmd.Cobra).
 		AddCommand(devcmd.Cobra).
-		AddCommand(edgeclustercmd.Cobra).
 		AddCommand(versioncmd.Cobra).
 		Build()
 	if err != nil {


### PR DESCRIPTION
# Description

This patch renames the `edgecluster` command to `create cluster`.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
