### PR TITLE
NO-ISSUE: Move exit error to separate package

### DIFF
--- a/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -26,6 +26,7 @@ import (
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/labels"
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
 )
@@ -101,7 +102,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 			"Failed to create JQ object: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Load the configuration:
@@ -121,7 +122,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 			"Failed to create client: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Enrich the configuration:
@@ -136,7 +137,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 			"Failed to create enricher: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 	err = enricher.Enrich(ctx, &c.config)
 	if err != nil {
@@ -145,7 +146,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 			"Failed to enrich configuration: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Create the applier:
@@ -163,7 +164,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 			"Failed to create applier: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Deploy the clusters:
@@ -176,7 +177,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 				"Failed to deploy cluster '%s': %v\n",
 				cluster.Name, err,
 			)
-			return internal.ExitError(1)
+			return exit.Error(1)
 		}
 	}
 
@@ -198,7 +199,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 					"Clusters aren't ready after waiting for %s\n",
 					c.flags.wait,
 				)
-				return internal.ExitError(1)
+				return exit.Error(1)
 			}
 			if err != nil {
 				return err
@@ -221,7 +222,7 @@ func (c *Command) loadConfiguration() error {
 					"empty and the 'EDGECLUSTERS_FILE' environment "+
 					"variable isn't set",
 			)
-			return internal.ExitError(1)
+			return exit.Error(1)
 		}
 	}
 
@@ -234,7 +235,7 @@ func (c *Command) loadConfiguration() error {
 			"Configuration file '%s' doesn't exist\n",
 			file,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Load the configuration:
@@ -248,7 +249,7 @@ func (c *Command) loadConfiguration() error {
 			"Failed to load configuration file '%s': %v\n",
 			file, err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	return nil

--- a/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
+++ b/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
@@ -29,6 +29,7 @@ import (
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/labels"
 )
 
@@ -79,7 +80,7 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 			"Failed to create JQ object: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Create the client for the API:
@@ -93,7 +94,7 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 			"Failed to create client: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	// Delete the namespaces:

--- a/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
+++ b/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/labels"
 )
 
@@ -84,7 +85,7 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 			"Failed to create applier: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 	err = applier.Apply(ctx, nil)
 	if err != nil {
@@ -93,7 +94,7 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 			"Failed to apply objects: %v\n",
 			err,
 		)
-		return internal.ExitError(1)
+		return exit.Error(1)
 	}
 
 	return nil

--- a/ztp/internal/exit/error.go
+++ b/ztp/internal/exit/error.go
@@ -12,21 +12,21 @@ implied. See the License for the specific language governing permissions and lim
 License.
 */
 
-package internal
+package exit
 
 import "fmt"
 
-// ExitError is an error type that contains a process exit code. This is itended for situations
-// where you want to call os.Exit only in one place, but also want some deeply nested functions to
-// decide what should be the exit code.
-type ExitError int
+// Error is an error type that contains a process exit code. This is itended for situations where
+// you want to call os.Exit only in one place, but also want some deeply nested functions to decide
+// what should be the exit code.
+type Error int
 
 // Error is the implementation of the error interface.
-func (e ExitError) Error() string {
+func (e Error) Error() string {
 	return fmt.Sprintf("%d", e)
 }
 
 // Code returns the exit code.
-func (e ExitError) Code() int {
+func (e Error) Code() int {
 	return int(e)
 }

--- a/ztp/main.go
+++ b/ztp/main.go
@@ -23,6 +23,7 @@ import (
 	createcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create"
 	devcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/dev"
 	versioncmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/version"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
 )
 
 func main() {
@@ -48,7 +49,7 @@ func main() {
 	// Run the tool:
 	err = tool.Run(ctx)
 	if err != nil {
-		exitErr, ok := err.(internal.ExitError)
+		exitErr, ok := err.(exit.Error)
 		if ok {
 			os.Exit(exitErr.Code())
 		} else {


### PR DESCRIPTION
# Description

This patch moves the `internal.ExitError` to a new `exit` package. That makes it more natural to use.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
