### PR TITLE
NO-ISSUE: Fix overlaping CIDRs

### DIFF
--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -403,7 +403,7 @@ func (e *Enricher) setNetworks(ctx context.Context, cluster *models.Cluster) err
 		HostPrefix: hardcodedClusterNetworkHostPrefix,
 	}}
 
-	_, machineNetworkCIDR, err := net.ParseCIDR(hardcodedClusterNetworkCIDR)
+	_, machineNetworkCIDR, err := net.ParseCIDR(hardcodedMachineNetworkCIDR)
 	if err != nil {
 		return fmt.Errorf("failed to parse machine network CIDR: %v", err)
 	}

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -439,5 +439,81 @@ var _ = Describe("Enricher", func() {
 			Expect(msg).To(ContainSubstring("find RHCOS release"))
 			Expect(msg).To(ContainSubstring("release.txt"))
 		})
+
+		It("Sets the hardcoded cluster CIDR", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
+				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Clusters[0].ClusterNetworks).To(HaveLen(1))
+			Expect(config.Clusters[0].ClusterNetworks[0].CIDR.String()).To(Equal(
+				"10.128.0.0/14",
+			))
+			Expect(config.Clusters[0].ClusterNetworks[0].HostPrefix).To(Equal(23))
+		})
+
+		It("Sets the hardcoded machine CIDR", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
+				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Clusters[0].MachineNetworks).To(HaveLen(1))
+			Expect(config.Clusters[0].MachineNetworks[0].CIDR.String()).To(Equal(
+				"192.168.7.0/24",
+			))
+		})
+
+		It("Sets the hardcoded service CIDR", func() {
+			config := &models.Config{
+				Properties: map[string]string{
+					"OC_OCP_VERSION":   "4.10.38",
+					"OC_OCP_TAG":       "4.10.38-x86_64",
+					"OC_RHCOS_RELEASE": "410.84.202210130022-0",
+				},
+				Clusters: []models.Cluster{{
+					Name: "my-cluster",
+					Nodes: []models.Node{
+						{
+							Kind: models.NodeKindControlPlane,
+							Name: "my-node",
+						},
+					},
+				}},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Clusters[0].ServiceNetworks).To(HaveLen(1))
+			Expect(config.Clusters[0].ServiceNetworks[0].CIDR.String()).To(Equal(
+				"172.30.0.0/16",
+			))
+		})
 	})
 })


### PR DESCRIPTION
# Description

Currently the enricher is setting the same CIDR for the cluster and machine networks. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
