### PR TITLE
NO-ISSUE: Fix assignment of internal IP addresses

### DIFF
--- a/ztp/go.mod
+++ b/ztp/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.5.0
 	golang.org/x/exp v0.0.0-20230118134722-a68e582fa157
@@ -20,7 +21,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 require (

--- a/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
+++ b/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
@@ -8,7 +8,6 @@ metadata:
  labels:
    nmstate_config_cluster_name: {{ $.Cluster.Name }}
 spec:
-
   interfaces:
   - name: {{ .ExternalNIC.Name }}
     macAddress: {{ .ExternalNIC.MAC }}
@@ -16,11 +15,8 @@ spec:
   - name: {{ .InternalNIC.Name }}
     macAddress: {{ .InternalNIC.MAC }}
   {{ end }}
-
   config:
-
     interfaces:
-
     - name: {{ .ExternalNIC.Name }}
       type: ethernet
       state: up
@@ -36,7 +32,6 @@ spec:
         auto-routes: true
       mtu: 1500
       mac-address: {{ .ExternalNIC.MAC }}
- 
     {{ if .InternalNIC.Name }}
     - name: {{ .InternalNIC.Name }}
       type: ethernet


### PR DESCRIPTION
# Description

Currently the internal IP addresses aren't calculated correctly. That results in incorrect nmstate configurations that are rejected. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
