### PR TITLE
NO-ISSUE: Fix calculation of prefix length

### DIFF
--- a/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
+++ b/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
@@ -46,7 +46,7 @@ spec:
         enabled: true
         address:
         - ip: {{ .InternalNIC.IP }}
-          prefix-length: {{ .InternalNIC.Mask }}
+          prefix-length: {{ .InternalNIC.Prefix }}
       mtu: 1500
     {{ else }}
     - name: {{ .ExternalNIC.Name }}.102

--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -435,7 +435,7 @@ func (e *Enricher) setInternalIP(ctx context.Context, index int, node *models.No
 	ip := slices.Clone(enricherMachineCIDR.IP)
 	ip[len(ip)-1] = byte(10 + index)
 	node.InternalNIC.IP = ip
-	node.InternalNIC.Mask = enricherMachineCIDR.Mask
+	node.InternalNIC.Prefix, _ = enricherMachineCIDR.Mask.Size()
 
 	return nil
 }

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -581,9 +581,13 @@ var _ = Describe("Enricher", func() {
 			Expect(err).ToNot(HaveOccurred())
 			cluster := config.Clusters[0]
 			Expect(cluster.Nodes[0].InternalNIC.IP.String()).To(Equal("192.168.7.10"))
+			Expect(cluster.Nodes[0].InternalNIC.Prefix).To(Equal(24))
 			Expect(cluster.Nodes[1].InternalNIC.IP.String()).To(Equal("192.168.7.11"))
+			Expect(cluster.Nodes[1].InternalNIC.Prefix).To(Equal(24))
 			Expect(cluster.Nodes[2].InternalNIC.IP.String()).To(Equal("192.168.7.12"))
+			Expect(cluster.Nodes[2].InternalNIC.Prefix).To(Equal(24))
 			Expect(cluster.Nodes[3].InternalNIC.IP.String()).To(Equal("192.168.7.13"))
+			Expect(cluster.Nodes[3].InternalNIC.Prefix).To(Equal(24))
 			Expect(cluster.API.VIP).To(Equal("192.168.7.242"))
 			Expect(cluster.Ingress.VIP).To(Equal("192.168.7.243"))
 		})
@@ -617,6 +621,7 @@ var _ = Describe("Enricher", func() {
 			Expect(err).ToNot(HaveOccurred())
 			cluster := config.Clusters[0]
 			Expect(cluster.Nodes[0].InternalNIC.IP.String()).To(Equal("192.168.7.10"))
+			Expect(cluster.Nodes[0].InternalNIC.Prefix).To(Equal(24))
 			Expect(cluster.API.VIP).To(BeEmpty())
 			Expect(cluster.Ingress.VIP).To(BeEmpty())
 		})

--- a/ztp/internal/models/nic.go
+++ b/ztp/internal/models/nic.go
@@ -17,8 +17,8 @@ package models
 import "net"
 
 type NIC struct {
-	IP   net.IP
-	MAC  string
-	Mask net.IPMask
-	Name string
+	IP     net.IP
+	MAC    string
+	Prefix int
+	Name   string
 }


### PR DESCRIPTION
# Description

Currently the CLI generates the nmstate `prefix-lenght` field as a hexadecimal number, which is rejected. This patch fixes that changing it to a decimal number.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
