### PR TITLE
NO-ISSUE: Fix calculation of DNS domain

### DIFF
--- a/ztp/internal/cmd/create_cluster_cmd_test.go
+++ b/ztp/internal/cmd/create_cluster_cmd_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Create cluster command", func() {
 					"auths": {
 						"cloud.openshift.com": {
 							"auth": "bXktdXNlcjpteS1wYXNz",
-							"email": "mary@example.com"
+							"email": "mary@my-domain.com"
 						}
 					}
 				}`),

--- a/ztp/internal/data/dev/files/pull-secret.json
+++ b/ztp/internal/data/dev/files/pull-secret.json
@@ -2,7 +2,7 @@
   "auths": {
     "cloud.openshift.com": {
       "auth": "bXktdXNlcjpteS1wYXNz",
-      "email": "mary@example.com"
+      "email": "mary@my-domain.com"
     }
   }
 }

--- a/ztp/internal/data/dev/objects/0020-ingresscontroller.yaml
+++ b/ztp/internal/data/dev/objects/0020-ingresscontroller.yaml
@@ -4,4 +4,4 @@ metadata:
   namespace: openshift-ingress-operator
   name: default
 status:
-  domain: example.com
+  domain: apps.my-hub.my-domain.com

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Enricher", func() {
 				"auths": {
 					"cloud.openshift.com": {
 						"auth": "eW91ci11c2VyOnlvdXItcGFzcw==",
-						"email": "joe@example.com"
+						"email": "joe@my-domain.com"
 					},
 				}
 			}`)
@@ -239,7 +239,7 @@ var _ = Describe("Enricher", func() {
 				"auths": {
 					"cloud.openshift.com": {
 						"auth": "bXktdXNlcjpteS1wYXNz",
-						"email": "mary@example.com"
+						"email": "mary@my-domain.com"
 					}
 				}
 			}`))
@@ -299,7 +299,7 @@ var _ = Describe("Enricher", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check that the flag has been set:
-			Expect(config.Clusters[0].DNS.Domain).To(Equal("example.com"))
+			Expect(config.Clusters[0].DNS.Domain).To(Equal("my-domain.com"))
 		})
 
 		It("Fails if the OCP version property isn't set", func() {


### PR DESCRIPTION
# Description

The DNS domain is currently copied from the configuration of the ingressc controller of the hub. For example, if that configuration is `apps.my-hub.my-domain.com` then the base DNS domain of the edge clusters will also be `apps.my-hub.my-domain.com`. But that is wrong; it should be only `my-domain.com`. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
