### PR TITLE
NO-ISSUE: Redirect klog to tool log

### DIFF
--- a/ztp/go.mod
+++ b/ztp/go.mod
@@ -66,7 +66,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.1
-	k8s.io/klog/v2 v2.80.1 // indirect
+	k8s.io/klog/v2 v2.80.1
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/ztp/internal/tool.go
+++ b/ztp/internal/tool.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	"k8s.io/klog/v2"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
 )
@@ -99,6 +100,12 @@ func (b *ToolBuilder) AddArg(value string) *ToolBuilder {
 // AddArgs adds a list of command line arguments.
 func (b *ToolBuilder) AddArgs(values ...string) *ToolBuilder {
 	b.args = append(b.args, values...)
+	return b
+}
+
+// SetArgs sets the list of command line arguments.
+func (b *ToolBuilder) SetArgs(values ...string) *ToolBuilder {
+	b.args = slices.Clone(values)
 	return b
 }
 
@@ -215,6 +222,7 @@ func (t *Tool) Run(ctx context.Context) error {
 		}
 		t.loggerOwned = true
 	}
+	klog.SetLogger(t.logger)
 
 	// Execute the main command:
 	t.logger.V(1).Info(
@@ -243,6 +251,7 @@ func (t *Tool) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	klog.SetLogger(t.logger)
 
 	// Populate the context:
 	ctx := cmd.Context()


### PR DESCRIPTION
# Description

This patch changes the tool so that it redirects 'klog' messages generated by the controller-runtime library to the log of the tool.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
