### PR TITLE
NO-ISSUE: Fetch external IP addresses from agents

### DIFF
--- a/ztp/internal/data.go
+++ b/ztp/internal/data.go
@@ -23,6 +23,7 @@ var DataFS embed.FS
 
 //go:generate -command get curl --silent --location --output
 //go:generate get data/dev/crds/0010_ingresscontroller.yaml   https://raw.githubusercontent.com/openshift/api/release-4.12/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+//go:generate get data/dev/crds/0015_agent.yaml               https://raw.githubusercontent.com/openshift/assisted-service/v2.14.1/config/crd/bases/agent-install.openshift.io_agents.yaml
 //go:generate get data/dev/crds/0020_agentclusterinstall.yaml https://raw.githubusercontent.com/openshift/assisted-service/v2.14.1/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
 //go:generate get data/dev/crds/0030_clusterdeployment.yaml   https://raw.githubusercontent.com/openshift/hive/master/config/crds/hive.openshift.io_clusterdeployments.yaml
 //go:generate get data/dev/crds/0040_managedcluster.yaml      https://raw.githubusercontent.com/open-cluster-management-io/api/v0.9.0/cluster/v1/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml

--- a/ztp/internal/data/dev/crds/0015_agent.yaml
+++ b/ztp/internal/data/dev/crds/0015_agent.yaml
@@ -1,0 +1,401 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: agents.agent-install.openshift.io
+spec:
+  group: agent-install.openshift.io
+  names:
+    kind: Agent
+    listKind: AgentList
+    plural: agents
+    singular: agent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of the cluster the Agent registered to.
+      jsonPath: .spec.clusterDeploymentName.name
+      name: Cluster
+      type: string
+    - description: The `Approve` state of the Agent.
+      jsonPath: .spec.approved
+      name: Approved
+      type: boolean
+    - description: The role (master/worker) of the Agent.
+      jsonPath: .status.role
+      name: Role
+      type: string
+    - description: The HostStage of the Agent.
+      jsonPath: .status.progress.currentStage
+      name: Stage
+      type: string
+    - description: The hostname of the Agent.
+      jsonPath: .status.inventory.hostname
+      name: Hostname
+      priority: 1
+      type: string
+    - description: The requested hostname for the Agent.
+      jsonPath: .spec.hostname
+      name: Requested Hostname
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Agent is the Schema for the hosts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentSpec defines the desired state of Agent
+            properties:
+              approved:
+                type: boolean
+              clusterDeploymentName:
+                description: ClusterReference represents a Cluster Reference. It has
+                  enough information to retrieve cluster in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      cluster resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the cluster
+                      name must be unique.
+                    type: string
+                type: object
+              hostname:
+                type: string
+              ignitionConfigOverrides:
+                description: Json formatted string containing the user overrides for
+                  the host's ignition config
+                type: string
+              ignitionEndpointTokenReference:
+                description: IgnitionEndpointTokenReference references a secret containing
+                  an Authorization Bearer token to fetch the ignition from ignition_endpoint_url.
+                properties:
+                  name:
+                    description: Name is the name of the secret containing the ignition
+                      endpoint token.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the secret containing
+                      the ignition endpoint token.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              installation_disk_id:
+                description: InstallationDiskID defines the installation destination
+                  disk (must be equal to the inventory disk id).
+                type: string
+              installerArgs:
+                description: Json formatted string containing the user overrides for
+                  the host's coreos installer args
+                type: string
+              machineConfigPool:
+                type: string
+              role:
+                description: "HostRole host role \n swagger:model host-role"
+                type: string
+            required:
+            - approved
+            - role
+            type: object
+          status:
+            description: AgentStatus defines the observed state of Agent
+            properties:
+              bootstrap:
+                type: boolean
+              conditions:
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              debugInfo:
+                description: DebugInfo includes information for debugging the installation
+                  process.
+                properties:
+                  eventsURL:
+                    description: EventsURL specifies an HTTP/S URL that contains events
+                      which occured during the cluster installation process
+                    type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs
+                      tar file.
+                    type: string
+                  state:
+                    description: Current state of the Agent
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of
+                      the Agent
+                    type: string
+                type: object
+              installation_disk_id:
+                description: InstallationDiskID is the disk that will be used for
+                  the installation.
+                type: string
+              inventory:
+                properties:
+                  bmcAddress:
+                    type: string
+                  bmcV6Address:
+                    type: string
+                  boot:
+                    properties:
+                      currentBootMode:
+                        type: string
+                      pxeInterface:
+                        type: string
+                    type: object
+                  cpu:
+                    properties:
+                      architecture:
+                        type: string
+                      clockMegahertz:
+                        description: 'Name in REST API: frequency'
+                        format: int64
+                        type: integer
+                      count:
+                        format: int64
+                        type: integer
+                      flags:
+                        items:
+                          type: string
+                        type: array
+                      modelName:
+                        type: string
+                    type: object
+                  disks:
+                    items:
+                      properties:
+                        bootable:
+                          type: boolean
+                        byID:
+                          type: string
+                        byPath:
+                          type: string
+                        driveType:
+                          type: string
+                        hctl:
+                          type: string
+                        id:
+                          type: string
+                        installationEligibility:
+                          properties:
+                            eligible:
+                              type: boolean
+                            notEligibleReasons:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - notEligibleReasons
+                          type: object
+                        ioPerf:
+                          properties:
+                            syncDurationMilliseconds:
+                              description: 99th percentile of fsync duration in milliseconds
+                              format: int64
+                              type: integer
+                          type: object
+                        model:
+                          type: string
+                        name:
+                          type: string
+                        path:
+                          type: string
+                        serial:
+                          type: string
+                        sizeBytes:
+                          format: int64
+                          type: integer
+                        smart:
+                          type: string
+                        vendor:
+                          type: string
+                        wwn:
+                          type: string
+                      required:
+                      - id
+                      type: object
+                    type: array
+                  hostname:
+                    type: string
+                  interfaces:
+                    items:
+                      properties:
+                        biosDevName:
+                          type: string
+                        clientID:
+                          type: string
+                        flags:
+                          items:
+                            type: string
+                          type: array
+                        hasCarrier:
+                          type: boolean
+                        ipV4Addresses:
+                          items:
+                            type: string
+                          type: array
+                        ipV6Addresses:
+                          items:
+                            type: string
+                          type: array
+                        macAddress:
+                          type: string
+                        mtu:
+                          format: int64
+                          type: integer
+                        name:
+                          type: string
+                        product:
+                          type: string
+                        speedMbps:
+                          format: int64
+                          type: integer
+                        vendor:
+                          type: string
+                      required:
+                      - flags
+                      - ipV4Addresses
+                      - ipV6Addresses
+                      type: object
+                    type: array
+                  memory:
+                    properties:
+                      physicalBytes:
+                        format: int64
+                        type: integer
+                      usableBytes:
+                        format: int64
+                        type: integer
+                    type: object
+                  reportTime:
+                    description: 'Name in REST API: timestamp'
+                    format: date-time
+                    type: string
+                  systemVendor:
+                    properties:
+                      manufacturer:
+                        type: string
+                      productName:
+                        type: string
+                      serialNumber:
+                        type: string
+                      virtual:
+                        type: boolean
+                    type: object
+                type: object
+              ntpSources:
+                items:
+                  properties:
+                    sourceName:
+                      type: string
+                    sourceState:
+                      description: "SourceState source state \n swagger:model source_state"
+                      type: string
+                  type: object
+                type: array
+              progress:
+                properties:
+                  currentStage:
+                    description: current installation stage
+                    type: string
+                  installationPercentage:
+                    description: Estimate progress (percentage)
+                    format: int64
+                    type: integer
+                  progressInfo:
+                    description: Additional information for the current installation
+                      stage
+                    type: string
+                  progressStages:
+                    description: All stages (ordered by their appearance) for this
+                      agent
+                    items:
+                      description: "HostStage host stage \n swagger:model host-stage"
+                      type: string
+                    type: array
+                  stageStartTime:
+                    description: 'host field: progress: stage_started_at'
+                    format: date-time
+                    type: string
+                  stageUpdateTime:
+                    description: 'host field: progress: stage_updated_at'
+                    format: date-time
+                    type: string
+                type: object
+              role:
+                description: "HostRole host role \n swagger:model host-role"
+                type: string
+              validationsInfo:
+                additionalProperties:
+                  items:
+                    properties:
+                      id:
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - id
+                    - message
+                    - status
+                    type: object
+                  type: array
+                description: ValidationsInfo is a JSON-formatted string containing
+                  the validation results for each validation id grouped by category
+                  (network, hosts-data, etc.)
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/ztp/internal/gvks.go
+++ b/ztp/internal/gvks.go
@@ -19,6 +19,13 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 // This file contains constants for some GroupVersionKinds that are used frequently in the project.
 
 var (
+	AgentGVK = schema.GroupVersionKind{
+		Group:   "agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "Agent",
+	}
+	AgentListGVK = listGVK(AgentGVK)
+
 	AgentClusterIntallGVK = schema.GroupVersionKind{
 		Group:   "extensions.hive.openshift.io",
 		Version: "v1beta1",

--- a/ztp/internal/jq_test.go
+++ b/ztp/internal/jq_test.go
@@ -252,4 +252,33 @@ var _ = Describe("JQ", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(x).To(Equal(42))
 	})
+
+	It("Accepts struct output", func() {
+		// Create the instance:
+		jq, err := NewJQ().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check that it writes into a struct option:
+		type Point struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		}
+		var p Point
+		err = jq.QueryString(
+			`{
+				"x": .x,
+				"y": .y
+			}`,
+			`{
+				"x": 42,
+				"y": 24
+			}`,
+			&p,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(p.X).To(Equal(42))
+		Expect(p.Y).To(Equal(24))
+	})
 })


### PR DESCRIPTION
# Description

This patch changes the enricher so that it fetchs the IP addresses of the external interfaces of the nodes of the clusters from the `Agent` objects, if they exist.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
