### PR TITLE
NO-ISSUE: Get kubeconfig from secret

### DIFF
--- a/ztp/internal/client.go
+++ b/ztp/internal/client.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -94,6 +95,19 @@ func (b *ClientBuilder) Build() (result clnt.WithWatch, err error) {
 
 	// Create the client:
 	delegate, err := clnt.NewWithWatch(config, clnt.Options{})
+	if err != nil {
+		return
+	}
+
+	// Send an initial request to force the discovery process, this way that noise will be at
+	// the beginning of the log, and also if the discovery process fails we will report the
+	// error earlier.
+	info := &corev1.ConfigMap{}
+	key := clnt.ObjectKey{
+		Namespace: "kube-public",
+		Name:      "cluster-info",
+	}
+	err = delegate.Get(context.Background(), key, info)
 	if err != nil {
 		return
 	}

--- a/ztp/internal/models/cluster.go
+++ b/ztp/internal/models/cluster.go
@@ -28,4 +28,5 @@ type Cluster struct {
 	ClusterNetworks []ClusterNetwork
 	MachineNetworks []MachineNetwork
 	ServiceNetworks []ServiceNetwork
+	Kubeconfig      []byte
 }


### PR DESCRIPTION
# Description

This patch changes the enricher so that it gets the kubeconfig of the cluster from the `...-admin-kubeconfig` secret, if it exists.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
