### PR TITLE
NO-ISSUE: Calculate image set

### DIFF
--- a/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -183,7 +183,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 
 	// Deploy the clusters:
 	for _, cluster := range c.config.Clusters {
-		err = c.deploy(ctx, &cluster)
+		err = c.deploy(ctx, cluster)
 		if err != nil {
 			fmt.Fprintf(
 				c.tool.Err(),
@@ -205,7 +205,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 		ctx, cancel = context.WithTimeout(ctx, c.flags.wait)
 		defer cancel()
 		for _, cluster := range c.config.Clusters {
-			err = c.wait(ctx, &cluster)
+			err = c.wait(ctx, cluster)
 			if os.IsTimeout(err) {
 				fmt.Fprintf(
 					c.tool.Err(),

--- a/ztp/internal/cmd/create_cluster_cmd_test.go
+++ b/ztp/internal/cmd/create_cluster_cmd_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Create cluster command", func() {
 	Context("Simple SNO cluster", Ordered, func() {
 		var (
 			tmp    string
-			env    map[string]string
 			client clnt.WithWatch
 		)
 
@@ -89,29 +88,17 @@ var _ = Describe("Create cluster command", func() {
 					      storage_disk:
 					      - /dev/vdb
 				`),
-				"pull.json",
-				Dedent(`{
-					"auths": {
-						"cloud.openshift.com": {
-							"auth": "bXktdXNlcjpteS1wYXNz",
-							"email": "mary@my-domain.com"
-						}
-					}
-				}`),
 			)
-
-			// Prepare the environment variables:
-			env = map[string]string{
-				"EDGECLUSTERS_FILE": filepath.Join(tmp, "config.yaml"),
-				"CLUSTERIMAGESET":   "my-image",
-			}
 
 			// Run the command:
 			tool, err := internal.NewTool().
 				SetLogger(logger).
-				AddArgs("ztp", "create", "cluster", "--wait=0").
+				SetArgs(
+					"ztp", "create", "cluster",
+					"--config", filepath.Join(tmp, "config.yaml"),
+					"--wait", "0",
+				).
 				AddCommand(createcmd.Cobra).
-				SetEnv(env).
 				SetIn(&bytes.Buffer{}).
 				SetOut(GinkgoWriter).
 				SetErr(GinkgoWriter).
@@ -284,9 +271,12 @@ var _ = Describe("Create cluster command", func() {
 			// Run the command again:
 			tool, err := internal.NewTool().
 				SetLogger(logger).
-				AddArgs("ztp", "create", "cluster", "--wait=0").
+				SetArgs(
+					"ztp", "create", "cluster",
+					"--config", filepath.Join(tmp, "config.yaml"),
+					"--wait", "0",
+				).
 				AddCommand(createcmd.Cobra).
-				SetEnv(env).
 				SetIn(&bytes.Buffer{}).
 				SetOut(GinkgoWriter).
 				SetErr(GinkgoWriter).

--- a/ztp/internal/cmd/delete/cluster/delete_cluster_cmd.go
+++ b/ztp/internal/cmd/delete/cluster/delete_cluster_cmd.go
@@ -160,7 +160,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 
 	// Delete the clusters:
 	for _, cluster := range c.config.Clusters {
-		err = c.delete(ctx, &cluster)
+		err = c.delete(ctx, cluster)
 		if err != nil {
 			fmt.Fprintf(
 				c.tool.Err(),

--- a/ztp/internal/config.go
+++ b/ztp/internal/config.go
@@ -193,10 +193,10 @@ func (l *ConfigLoader) loadClusters(content any, config *models.Config) error {
 	}
 	for _, item := range data {
 		for name, value := range item {
-			cluster := models.Cluster{
+			cluster := &models.Cluster{
 				Name: name,
 			}
-			err = l.loadCluster(value, &cluster)
+			err = l.loadCluster(value, cluster)
 			if err != nil {
 				return err
 			}
@@ -224,10 +224,10 @@ func (l *ConfigLoader) loadCluster(content any, cluster *models.Cluster) error {
 				return err
 			}
 		default:
-			node := models.Node{
+			node := &models.Node{
 				Name: name,
 			}
-			err = l.loadNode(value, &node)
+			err = l.loadNode(value, node)
 			if err != nil {
 				return err
 			}

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -42,10 +42,9 @@ import (
 
 var _ = Describe("Enricher", Ordered, func() {
 	var (
-		ctx        context.Context
-		logger     logr.Logger
-		client     clnt.WithWatch
-		properties map[string]string
+		ctx    context.Context
+		logger logr.Logger
+		client clnt.WithWatch
 	)
 
 	BeforeAll(func() {
@@ -65,20 +64,6 @@ var _ = Describe("Enricher", Ordered, func() {
 			SetLogger(logger).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	BeforeEach(func() {
-		// Create a context:
-		ctx = context.Background()
-
-		// Prepare the default properties. These are convenient in most tests because
-		// otherwise the enricher will try to fetch the `release.txt` file to determine the
-		// values, and that may fail due to network issues.
-		properties = map[string]string{
-			"OC_OCP_VERSION":   "4.10.38",
-			"OC_OCP_TAG":       "4.10.38-x86_64",
-			"OC_RHCOS_RELEASE": "410.84.202210130022-0",
-		}
 	})
 
 	Context("Creation", func() {
@@ -107,8 +92,8 @@ var _ = Describe("Enricher", Ordered, func() {
 
 	Context("Usage", func() {
 		var (
-			defaultImageSet string
-			enricher        *Enricher
+			enricher   *Enricher
+			properties map[string]string
 		)
 
 		BeforeEach(func() {
@@ -121,18 +106,28 @@ var _ = Describe("Enricher", Ordered, func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
-			// Prepare the default image set:
-			defaultImageSet = "my-image-set"
+			// Prepare the default properties. These are convenient in most tests
+			// because otherwise the enricher will try to fetch the `release.txt` file
+			// to determine the values, and that may fail due to network issues.
+			properties = map[string]string{
+				"OC_OCP_VERSION":   "4.10.38",
+				"OC_OCP_TAG":       "4.10.38-x86_64",
+				"OC_RHCOS_RELEASE": "410.84.202210130022-0",
+				"clusterimageset":  "openshift-v4.10.38",
+			}
 
 			// Create the enricher:
 			enricher, err = NewEnricher().
 				SetLogger(logger).
 				SetClient(client).
-				SetEnv(map[string]string{
-					"CLUSTERIMAGESET": defaultImageSet,
-				}).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		BeforeEach(func() {
+			// Create a context:
+			ctx = context.Background()
+
 		})
 
 		It("Sets the SNO flag to true when there is only one control plane node", func() {
@@ -140,9 +135,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -164,9 +159,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node-0",
@@ -206,10 +201,10 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name:       name,
 					PullSecret: custom,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -231,9 +226,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -262,12 +257,12 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
 					DNS: models.DNS{
 						Domain: "example.net",
 					},
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -289,9 +284,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -421,9 +416,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -444,9 +439,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -466,9 +461,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-node",
@@ -488,9 +483,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-master-0",
@@ -561,9 +556,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Kind: models.NodeKindControlPlane,
 							Name: "my-master-0",
@@ -604,7 +599,7 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
 					SSH: models.SSH{
 						PublicKey:  publicKey,
@@ -664,7 +659,7 @@ var _ = Describe("Enricher", Ordered, func() {
 			// Enrich the cluster:
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
 				}},
 			}
@@ -727,9 +722,9 @@ var _ = Describe("Enricher", Ordered, func() {
 			// Enrich the cluster:
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
-					Nodes: []models.Node{
+					Nodes: []*models.Node{
 						{
 							Name: "master0",
 							ExternalNIC: models.NIC{
@@ -802,7 +797,7 @@ var _ = Describe("Enricher", Ordered, func() {
 			// Enrich the cluster:
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name: name,
 				}},
 			}
@@ -819,7 +814,7 @@ var _ = Describe("Enricher", Ordered, func() {
 			name := fmt.Sprintf("my-%s", uuid.NewString())
 			config := &models.Config{
 				Properties: properties,
-				Clusters: []models.Cluster{{
+				Clusters: []*models.Cluster{{
 					Name:       name,
 					Kubeconfig: []byte("your-kubeconfig"),
 				}},
@@ -830,6 +825,45 @@ var _ = Describe("Enricher", Ordered, func() {
 			// Verify external IP addresses:
 			cluster := config.Clusters[0]
 			Expect(string(cluster.Kubeconfig)).To(Equal("your-kubeconfig"))
+		})
+
+		It("Calculates the default cluster image set", func() {
+			delete(properties, "clusterimageset")
+			config := &models.Config{
+				Properties: properties,
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Properties).To(HaveKeyWithValue("clusterimageset", "openshift-v4.10.38"))
+		})
+
+		It("Doesn't change the cluster image set if already set", func() {
+			name := fmt.Sprintf("my-%s", uuid.NewString())
+			config := &models.Config{
+				Properties: properties,
+				Clusters: []*models.Cluster{{
+					Name: name,
+				}},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			cluster := config.Clusters[0]
+			Expect(cluster.ImageSet).To(Equal("openshift-v4.10.38"))
+		})
+
+		It("Doesn't change the cluster image set if already set", func() {
+			name := fmt.Sprintf("my-%s", uuid.NewString())
+			config := &models.Config{
+				Properties: properties,
+				Clusters: []*models.Cluster{{
+					Name:     name,
+					ImageSet: "my-image-set",
+				}},
+			}
+			err := enricher.Enrich(ctx, config)
+			Expect(err).ToNot(HaveOccurred())
+			cluster := config.Clusters[0]
+			Expect(cluster.ImageSet).To(Equal("my-image-set"))
 		})
 	})
 })

--- a/ztp/internal/models/cluster.go
+++ b/ztp/internal/models/cluster.go
@@ -20,13 +20,13 @@ type Cluster struct {
 	ImageSet        string
 	Ingress         Ingress
 	Name            string
-	Nodes           []Node
+	Nodes           []*Node
 	PullSecret      []byte
 	SNO             bool
 	SSH             SSH
 	TPM             bool
-	ClusterNetworks []ClusterNetwork
-	MachineNetworks []MachineNetwork
-	ServiceNetworks []ServiceNetwork
+	ClusterNetworks []*ClusterNetwork
+	MachineNetworks []*MachineNetwork
+	ServiceNetworks []*ServiceNetwork
 	Kubeconfig      []byte
 }

--- a/ztp/internal/models/config.go
+++ b/ztp/internal/models/config.go
@@ -16,5 +16,5 @@ package models
 
 type Config struct {
 	Properties map[string]string
-	Clusters   []Cluster
+	Clusters   []*Cluster
 }

--- a/ztp/internal/models/properties.go
+++ b/ztp/internal/models/properties.go
@@ -34,3 +34,8 @@ const OCPRCHOSReleaseProperty = "OC_RHCOS_RELEASE"
 // `release.txt` file. The default is to use `https://mirror.openshift.com/pub/openshift-v4/clients/ocp/`
 // and there is usually no need to change it. This is only intended for use in unit tests.
 const OCPMirrorProperty = "OC_OCP_MIRROR"
+
+// ClusterImageSetProperty is the name of the Hive cluster image set that will be used for the
+// installation of the cluster. The default is to calculate it from the OCM version. For example, if
+// the OCP version is `4.10.38` then the value will be `openshift-v4.10.38`.
+const ClusterImageSetProperty = "clusterimageset"


### PR DESCRIPTION
# Description

Currently the tool expects the cluster image set in the `CLUSTERIMAGESET` environment variable, but this is just an itermediate variable used by the shell scripts, the value should be extracted from the configuration or calculated. This patch addresses that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested with the included unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
