### PR TITLE
NO-ISSUE: Add `ztp` binary to pipeline image

### DIFF
--- a/images/Containerfile.pipeline
+++ b/images/Containerfile.pipeline
@@ -1,3 +1,14 @@
+# This is the builder image, see the next `FROM` directive for the beginning of the pipeline image:
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+
+# Copy the source code into the container:
+COPY ztp .
+
+# Run the build:
+RUN go build -mod=mod -o /ztp
+
+# This is the pipeline image, which includes tools, scripts and the CLI binary built by the previous
+# builder image:
 FROM ubi8
 
 ENV JQ_VERSION=1.6
@@ -15,3 +26,6 @@ RUN dnf install -y bind-utils openssl openssh-clients httpd-tools conmon skopeo 
     dnf clean all &&  rm -rf /var/cache/yum
 
 COPY . /opt/ztp
+
+# Install the CLI binary:
+COPY --from=builder /ztp /usr/bin/


### PR DESCRIPTION
# Description

This patch changes the pipeline image so that it builds and includes the `ztp` binary.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually with `make build-pipe-image`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
