### PR TITLE
NO-ISSUE: Don't try to get `cluster-info`

### DIFF
--- a/ztp/internal/client.go
+++ b/ztp/internal/client.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -95,19 +94,6 @@ func (b *ClientBuilder) Build() (result clnt.WithWatch, err error) {
 
 	// Create the client:
 	delegate, err := clnt.NewWithWatch(config, clnt.Options{})
-	if err != nil {
-		return
-	}
-
-	// Send an initial request to force the discovery process, this way that noise will be at
-	// the beginning of the log, and also if the discovery process fails we will report the
-	// error earlier.
-	info := &corev1.ConfigMap{}
-	key := clnt.ObjectKey{
-		Namespace: "kube-public",
-		Name:      "cluster-info",
-	}
-	err = delegate.Get(context.Background(), key, info)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
# Description

Currently the code that creates the API client tries to get the `kube-public/cluster-info` configmap in order to check that the connection is working, but this doesn't work with OpenShift as that configmap doesn't exist. This patch removes that code.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
