### PR TITLE
NO-ISSUE: Fix use of `-w` without `name` in docs

### DIFF
--- a/documentation/ztp-for-factories/ztp-install-factory-edge-pipeline.adoc
+++ b/documentation/ztp-for-factories/ztp-install-factory-edge-pipeline.adoc
@@ -193,7 +193,14 @@ $ export KUBECONFIG=<path_to_kubeconfig>/kubeconfig-file
 +
 [source,terminal]
 ----
-$ tkn pipeline start -n edgecluster-deployer edgeclusters-config="$(cat /path-to-edgecluster-yaml/edgeclusters.yaml)" -p kubeconfig=${KUBECONFIG} -w=ztp,claimName=ztp-pvc --timeout 5h --use-param-defaults deploy-ztp-edgeclusters
+$ tkn pipeline start \
+-n edgecluster-deployer \
+-p edgeclusters-config="$(cat /path-to-edgecluster-yaml/edgeclusters.yaml)" \
+-p kubeconfig=${KUBECONFIG} \
+-w name=ztp,claimName=ztp-pvc \
+--timeout 5h \
+--use-param-defaults \
+deploy-ztp-edgeclusters
 ----
 +
 [NOTE]

--- a/documentation/ztp-for-factories/ztp-install-factory-pipeline.adoc
+++ b/documentation/ztp-for-factories/ztp-install-factory-pipeline.adoc
@@ -40,7 +40,14 @@ config:
 +
 [source,terminal]
 ----
-$ tkn pipeline start -n edgecluster-deployer edgeclusters-config="$(cat /path-to-edgecluster.yaml/edgeclusters.yaml)" -p kubeconfig=${KUBECONFIG} -w=ztp,claimName=ztp-pvc --timeout 5h --use-param-defaults deploy-ztp-hub
+$ tkn pipeline start \
+-n edgecluster-deployer \
+-p edgeclusters-config="$(cat /path-to-edgecluster.yaml/edgeclusters.yaml)" \
+-p kubeconfig=${KUBECONFIG} \
+-w name=ztp,claimName=ztp-pvc \
+--timeout 5h \
+--use-param-defaults \
+deploy-ztp-hub
 ----
 +
 [NOTE]


### PR DESCRIPTION
# Description

Currently there are a couple of places in the documentation where the `-w` option of the `tnk pipeline start` command is missing the `name` part that indicates the name of the workspace. As a result those commands don't work. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
