### PR TITLE
NO-ISSUE: Load Kubeconfig fron default locations

### DIFF
--- a/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -65,7 +65,6 @@ type Command struct {
 		wait   time.Duration
 	}
 	logger  logr.Logger
-	env     map[string]string
 	jq      *internal.JQ
 	tool    *internal.Tool
 	config  models.Config
@@ -89,9 +88,6 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	c.logger = internal.LoggerFromContext(ctx)
 	c.tool = internal.ToolFromContext(ctx)
 
-	// Get the environment:
-	c.env = c.tool.Env()
-
 	// Create the JQ object:
 	c.jq, err = internal.NewJQ().
 		SetLogger(c.logger).
@@ -114,7 +110,6 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	// Create the client for the API:
 	c.client, err = internal.NewClient().
 		SetLogger(c.logger).
-		SetEnv(c.env).
 		Build()
 	if err != nil {
 		fmt.Fprintf(
@@ -128,7 +123,6 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	// Enrich the configuration:
 	enricher, err := internal.NewEnricher().
 		SetLogger(c.logger).
-		SetEnv(c.env).
 		SetClient(c.client).
 		Build()
 	if err != nil {
@@ -227,7 +221,7 @@ func (c *Command) loadConfiguration() error {
 	file := c.flags.config
 	if file == "" {
 		var ok bool
-		file, ok = c.env["EDGECLUSTERS_FILE"]
+		file, ok = os.LookupEnv("EDGECLUSTERS_FILE")
 		if !ok {
 			fmt.Fprintf(
 				c.tool.Out(),

--- a/ztp/internal/cmd/delete/cluster/delete_cluster_cmd.go
+++ b/ztp/internal/cmd/delete/cluster/delete_cluster_cmd.go
@@ -56,7 +56,6 @@ type Command struct {
 		config string
 	}
 	logger  logr.Logger
-	env     map[string]string
 	tool    *internal.Tool
 	config  models.Config
 	client  clnt.WithWatch
@@ -79,9 +78,6 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	c.logger = internal.LoggerFromContext(ctx)
 	c.tool = internal.ToolFromContext(ctx)
 
-	// Get the environment:
-	c.env = c.tool.Env()
-
 	// Load the configuration:
 	err = c.loadConfiguration()
 	if err != nil {
@@ -91,7 +87,6 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	// Create the client for the API:
 	c.client, err = internal.NewClient().
 		SetLogger(c.logger).
-		SetEnv(c.env).
 		Build()
 	if err != nil {
 		fmt.Fprintf(
@@ -105,7 +100,6 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	// Enrich the configuration:
 	enricher, err := internal.NewEnricher().
 		SetLogger(c.logger).
-		SetEnv(c.env).
 		SetClient(c.client).
 		Build()
 	if err != nil {
@@ -179,7 +173,7 @@ func (c *Command) loadConfiguration() error {
 	file := c.flags.config
 	if file == "" {
 		var ok bool
-		file, ok = c.env["EDGECLUSTERS_FILE"]
+		file, ok = os.LookupEnv("EDGECLUSTERS_FILE")
 		if !ok {
 			fmt.Fprintf(
 				c.tool.Out(),

--- a/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
+++ b/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
@@ -41,7 +41,6 @@ func Cobra() *cobra.Command {
 type Command struct {
 	logger logr.Logger
 	tool   *internal.Tool
-	env    map[string]string
 	client clnt.WithWatch
 }
 
@@ -59,13 +58,9 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 	c.logger = internal.LoggerFromContext(ctx)
 	c.tool = internal.ToolFromContext(ctx)
 
-	// Get the environment:
-	c.env = c.tool.Env()
-
 	// Create the client for the API:
 	c.client, err = internal.NewClient().
 		SetLogger(c.logger).
-		SetEnv(c.env).
 		Build()
 	if err != nil {
 		fmt.Fprintf(

--- a/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
+++ b/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
@@ -42,7 +42,6 @@ func Cobra() *cobra.Command {
 type Command struct {
 	logger logr.Logger
 	tool   *internal.Tool
-	env    map[string]string
 	client clnt.WithWatch
 }
 
@@ -60,13 +59,9 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 	c.logger = internal.LoggerFromContext(ctx)
 	c.tool = internal.ToolFromContext(ctx)
 
-	// Get the environment:
-	c.env = c.tool.Env()
-
 	// Create the client for the API:
 	c.client, err = internal.NewClient().
 		SetLogger(c.logger).
-		SetEnv(c.env).
 		Build()
 	if err != nil {
 		fmt.Fprintf(

--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +45,6 @@ import (
 type EnricherBuilder struct {
 	logger logr.Logger
 	client clnt.Client
-	env    map[string]string
 }
 
 // Enricher knows how to add information to the description of a cluster. Don't create instances of
@@ -54,16 +52,13 @@ type EnricherBuilder struct {
 type Enricher struct {
 	logger logr.Logger
 	client clnt.Client
-	env    map[string]string
 	jq     *JQ
 }
 
 // NewEnricher creates a builder that can then be used to create an object that knows how to add
 // information to the description of a cluster.
 func NewEnricher() *EnricherBuilder {
-	return &EnricherBuilder{
-		env: map[string]string{},
-	}
+	return &EnricherBuilder{}
 }
 
 // SetLogger sets the logger that the enricher will use to write log messages. This is mandatory.
@@ -76,12 +71,6 @@ func (b *EnricherBuilder) SetLogger(value logr.Logger) *EnricherBuilder {
 // order to extract the additional information.
 func (b *EnricherBuilder) SetClient(value clnt.Client) *EnricherBuilder {
 	b.client = value
-	return b
-}
-
-// SetEnv sets the environment variables that will be used by the enricher.
-func (b *EnricherBuilder) SetEnv(value map[string]string) *EnricherBuilder {
-	b.env = value
 	return b
 }
 
@@ -111,7 +100,6 @@ func (b *EnricherBuilder) Build() (result *Enricher, err error) {
 	result = &Enricher{
 		logger: b.logger,
 		client: b.client,
-		env:    maps.Clone(b.env),
 		jq:     jq,
 	}
 	return

--- a/ztp/main.go
+++ b/ztp/main.go
@@ -33,7 +33,6 @@ func main() {
 
 	// Create the tool:
 	tool, err := internal.NewTool().
-		SetEnv(os.Environ()).
 		AddArgs(os.Args...).
 		SetIn(os.Stdin).
 		SetOut(os.Stdout).


### PR DESCRIPTION
# Description

Currently the the tool creates the Kubernetes API client loading the `KUBECONFIG` environment variable explicitly. This is done in order to generate better error messages, but it generates problems when running the tool in environments where the configuration has to come from other places, specially when it has to come from the secrets mounted inside a Kubernetes pod. To address this issue this patch changes the tool so that it uses the same mechanism used by tools like `kubectl`.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
