### PR TITLE
NO-ISSUE: Fix cluster installed condition

### DIFF
--- a/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
+++ b/ztp/internal/cmd/create/cluster/create_cluster_cmd.go
@@ -369,7 +369,7 @@ func (c *Command) waitInstall(ctx context.Context, cluster *models.Cluster) erro
 		if err != nil {
 			return err
 		}
-		if status == "ready" {
+		if status == "True" {
 			fmt.Fprintf(
 				c.tool.Out(),
 				"Cluster '%s' is installed\n",


### PR DESCRIPTION
# Description

Currently the `ztp` tool waits till the `Completed` condition of the agent cluster install has status `ready`, but that will never happen because the values are `True` or `False`. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
