### PR TITLE
NO-ISSUE: Fetch custom registry CA

### DIFF
--- a/ztp/internal/models/properties.go
+++ b/ztp/internal/models/properties.go
@@ -39,3 +39,6 @@ const OCPMirrorProperty = "OC_OCP_MIRROR"
 // installation of the cluster. The default is to calculate it from the OCM version. For example, if
 // the OCP version is `4.10.38` then the value will be `openshift-v4.10.38`.
 const ClusterImageSetProperty = "clusterimageset"
+
+// RegistryProperty is the URL of a custom image registry to use for the clusters.
+const RegistryProperty = "REGISTRY"

--- a/ztp/internal/models/registry.go
+++ b/ztp/internal/models/registry.go
@@ -14,20 +14,7 @@ License.
 
 package models
 
-type Cluster struct {
-	API             API
-	DNS             DNS
-	ImageSet        string
-	Ingress         Ingress
-	Name            string
-	Nodes           []*Node
-	PullSecret      []byte
-	SNO             bool
-	SSH             SSH
-	TPM             bool
-	ClusterNetworks []*ClusterNetwork
-	MachineNetworks []*MachineNetwork
-	ServiceNetworks []*ServiceNetwork
-	Kubeconfig      []byte
-	Registry        Registry
+type Registry struct {
+	URL string
+	CA  []byte
 }


### PR DESCRIPTION
# Description

This patch changes the enricher so that it fetches the CA certificates of the custom registry addresses specified in the `REGISTRY` property of the configuration.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
