### PR TITLE
NO-ISSUE: Fix naming of nodes

### DIFF
--- a/ztp/internal/cmd/create_cluster_cmd_test.go
+++ b/ztp/internal/cmd/create_cluster_cmd_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Create cluster command", Ordered, func() {
 			object.SetGroupVersionKind(internal.NMStateConfigGVK)
 			key := clnt.ObjectKey{
 				Namespace: name,
-				Name:      fmt.Sprintf("ztpfw-%s-master-master0", name),
+				Name:      fmt.Sprintf("ztpfw-%s-master-0", name),
 			}
 			err := client.Get(ctx, key, object)
 			Expect(err).ToNot(HaveOccurred())
@@ -241,7 +241,7 @@ var _ = Describe("Create cluster command", Ordered, func() {
 			object := &corev1.Secret{}
 			key := clnt.ObjectKey{
 				Namespace: name,
-				Name:      fmt.Sprintf("ztpfw-%s-master-master0-bmc-secret", name),
+				Name:      fmt.Sprintf("ztpfw-%s-master-0-bmc-secret", name),
 			}
 			err := client.Get(ctx, key, object)
 			Expect(err).ToNot(HaveOccurred())
@@ -253,7 +253,7 @@ var _ = Describe("Create cluster command", Ordered, func() {
 			object.SetGroupVersionKind(internal.BareMetalHostGVK)
 			key := clnt.ObjectKey{
 				Namespace: name,
-				Name:      fmt.Sprintf("ztpfw-%s-master-master0", name),
+				Name:      fmt.Sprintf("ztpfw-%s-master-0", name),
 			}
 			err := client.Get(ctx, key, object)
 			Expect(err).ToNot(HaveOccurred())
@@ -392,7 +392,7 @@ var _ = Describe("Create cluster command", Ordered, func() {
 		bmhObject.SetGroupVersionKind(internal.BareMetalHostGVK)
 		bmhKey := clnt.ObjectKey{
 			Namespace: name,
-			Name:      fmt.Sprintf("ztpfw-%s-master-master0", name),
+			Name:      fmt.Sprintf("ztpfw-%s-master-0", name),
 		}
 		Eventually(func() error {
 			return client.Get(ctx, bmhKey, bmhObject)
@@ -517,7 +517,7 @@ var _ = Describe("Create cluster command", Ordered, func() {
 		bmhObject.SetGroupVersionKind(internal.BareMetalHostGVK)
 		bmhKey := clnt.ObjectKey{
 			Namespace: name,
-			Name:      fmt.Sprintf("ztpfw-%s-master-master0", name),
+			Name:      fmt.Sprintf("ztpfw-%s-master-0", name),
 		}
 		Eventually(func() error {
 			return client.Get(ctx, bmhKey, bmhObject)

--- a/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
+++ b/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
@@ -1,10 +1,10 @@
-{{ range .Cluster.Nodes }}
+{{ range .Cluster.ControlPlaneNodes }}
 ---
 apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig
 metadata:
  namespace: {{ $.Cluster.Name }}
- name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Name }}
+ name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}
  labels:
    nmstate_config_cluster_name: {{ $.Cluster.Name }}
 spec:

--- a/ztp/internal/data/cluster/objects/080-bmc-secret.yaml
+++ b/ztp/internal/data/cluster/objects/080-bmc-secret.yaml
@@ -1,10 +1,10 @@
-{{ range .Cluster.Nodes }}
+{{ range .Cluster.ControlPlaneNodes }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ $.Cluster.Name }}
-  name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Name }}-bmc-secret
+  name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}-bmc-secret
 type: Opaque
 data:
   username: {{ .BMC.User | base64 }}

--- a/ztp/internal/data/cluster/objects/090-baremetalhost.yaml
+++ b/ztp/internal/data/cluster/objects/090-baremetalhost.yaml
@@ -1,15 +1,15 @@
-{{ range .Cluster.Nodes }}
+{{ range .Cluster.ControlPlaneNodes }}
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Name }}
+  name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}
   namespace: {{ $.Cluster.Name }}
   labels:
     infraenvs.agent-install.openshift.io: {{ $.Cluster.Name }}
   annotations:
     inspect.metal3.io: disabled
-    bmac.agent-install.openshift.io/hostname: ztpfw-{{ $.Cluster.Name }}-master-{{ .Name }}
+    bmac.agent-install.openshift.io/hostname: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}
     bmac.agent-install.openshift.io/ignition-config-overrides: {{ execute "files/cfg-override-bmh.json" . | json }}
 spec:
   online: false
@@ -19,5 +19,5 @@ spec:
   bmc:
     disableCertificateVerification: true
     address: {{ .BMC.URL }}
-    credentialsName: ztpfw-{{ $.Cluster.Name }}-master-{{ .Name }}-bmc-secret
+    credentialsName: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}-bmc-secret
 {{ end}}

--- a/ztp/internal/models/cluster.go
+++ b/ztp/internal/models/cluster.go
@@ -31,3 +31,25 @@ type Cluster struct {
 	Kubeconfig      []byte
 	Registry        Registry
 }
+
+// ContorlPlaneNodes returns an slice containing only the control plane nodes of the cluster.
+func (c *Cluster) ControlPlaneNodes() []*Node {
+	var nodes []*Node
+	for _, node := range c.Nodes {
+		if node.Kind == NodeKindControlPlane {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+// WorkerNodes returns an slice containing only the workr nodes of the cluster.
+func (c *Cluster) WorkerNodes() []*Node {
+	var nodes []*Node
+	for _, node := range c.Nodes {
+		if node.Kind == NodeKindWorker {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}

--- a/ztp/internal/models/cluster_test.go
+++ b/ztp/internal/models/cluster_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package models
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Clusters", func() {
+	It("Filters nodes according to kind", func() {
+		cluster := &Cluster{
+			Nodes: []*Node{
+				{
+					Kind: NodeKindControlPlane,
+					Name: "master0",
+				},
+				{
+					Kind: NodeKindControlPlane,
+					Name: "master1",
+				},
+				{
+					Kind: NodeKindControlPlane,
+					Name: "master2",
+				},
+				{
+					Kind: NodeKindWorker,
+					Name: "worker0",
+				},
+				{
+					Kind: NodeKindWorker,
+					Name: "worker1",
+				},
+			},
+		}
+		controlPlaneNodes := cluster.ControlPlaneNodes()
+		Expect(controlPlaneNodes).To(HaveLen(3))
+		Expect(controlPlaneNodes[0].Kind).To(Equal(NodeKindControlPlane))
+		Expect(controlPlaneNodes[1].Kind).To(Equal(NodeKindControlPlane))
+		Expect(controlPlaneNodes[2].Kind).To(Equal(NodeKindControlPlane))
+		workerNodes := cluster.WorkerNodes()
+		Expect(workerNodes).To(HaveLen(2))
+		Expect(workerNodes[0].Kind).To(Equal(NodeKindWorker))
+		Expect(workerNodes[1].Kind).To(Equal(NodeKindWorker))
+	})
+})

--- a/ztp/internal/models/node.go
+++ b/ztp/internal/models/node.go
@@ -14,6 +14,8 @@ License.
 
 package models
 
+import "regexp"
+
 type NodeKind string
 
 const (
@@ -31,3 +33,18 @@ type Node struct {
 	ExternalNIC  NIC
 	IgnoredNICs  []string
 }
+
+// Index extracts the index from the name of the node. For example, if the name is `worker123` then
+// the index will be `123`. This is needed because currently some of our pipelines rely on node
+// names having that index. This will be removed when those pipelines have been updatedd, so refrain
+// from using it.
+func (n *Node) Index() string {
+	matches := nodeIndexRE.FindStringSubmatch(n.Name)
+	if matches == nil {
+		return ""
+	}
+	return matches[1]
+}
+
+// nodeIndexRE is the regular expression used to extract the numeric index from the name of the node.
+var nodeIndexRE = regexp.MustCompile(`(\d+)$`)

--- a/ztp/internal/models/node_test.go
+++ b/ztp/internal/models/node_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package models
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Nodes", func() {
+	DescribeTable(
+		"Extracts index from node name",
+		func(node *Node, expected string) {
+			actual := node.Index()
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"Control plane node one digit",
+			&Node{
+				Name: "master0",
+			},
+			"0",
+		),
+		Entry(
+			"Control plane node two digits",
+			&Node{
+				Name: "master12",
+			},
+			"12",
+		),
+		Entry(
+			"Control plane node three digits",
+			&Node{
+				Name: "master123",
+			},
+			"123",
+		),
+		Entry(
+			"Worker node one digit",
+			&Node{
+				Name: "worker0",
+			},
+			"0",
+		),
+		Entry(
+			"Worker node two digits",
+			&Node{
+				Name: "worker12",
+			},
+			"12",
+		),
+		Entry(
+			"Worker node three digits",
+			&Node{
+				Name: "worker123",
+			},
+			"123",
+		),
+		Entry(
+			"Unknown node kind",
+			&Node{
+				Name: "junk123",
+			},
+			"123",
+		),
+		Entry(
+			"No index",
+			&Node{
+				Name: "worker",
+			},
+			"",
+		),
+	)
+})

--- a/ztp/internal/models/suite_test.go
+++ b/ztp/internal/models/suite_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestModels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Models")
+}


### PR DESCRIPTION
# Description

Currently if the name of a node in the configuration file is `master0` the resulting node name will be `ztpfw-...-master-master0`. That works fine for the creation of the cluster, but it breaks the scripts that run later to create the registry because they expect the nodes to be named `ztpfw-...-master-0`. It would be good to make that code independent of the names assiged to nodes, but for now we will instead change the CLI so that it generates the expected names.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
