### PR TITLE
MGMT-13114: Replace `deploy-edgecluster` scripts with `ztp`

### DIFF
--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -15,6 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
+    - name: ztp-log-level
+      type: string
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -53,6 +56,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
@@ -15,6 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
+    - name: ztp-log-level
+      type: string
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -53,6 +56,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -15,6 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
+    - name: ztp-log-level
+      type: string
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -54,6 +57,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -15,6 +15,12 @@ spec:
     - name: mock
       type: string
       default: "false"
+    - name: ztp-log-level
+      type: string
+      default: "0"
+    - name: ztp-log-level
+      type: string
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -54,6 +60,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
@@ -12,9 +12,6 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
-    - name: kubeconfig
-      type: string
-      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -24,37 +21,14 @@ spec:
     - name: mock
       type: string
       default: "false"
+    - name: ztp-log-level
+      type: string
+      default: "0"
   stepTemplate:
     env:
-      - name: WORKDIR
-        value: "/workspace/ztp/$(params.pipeline-name)"
-      - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
-      - name: EDGECLUSTERS_CONFIG
-        value: $(params.edgeclusters-config)
-      - name: KUBECONFIG
-        value: "$(workspaces.ztp.path)/kubeconfig"
-      - name: DEPLOY_EDGECLUSTERS_DIR
-        value: "deploy-edgecluster"
-      - name: SHARED_DIR
-        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
-    - name: render-edgeclusters
-      image: "$(params.ztp-container-image)"
-      imagePullPolicy: Always
-      script: |
-        #!/usr/bin/bash
-
-        if [[ "${MOCK}" == 'false' ]]; then
-          cd ${WORKDIR}/${DEPLOY_EDGECLUSTERS_DIR}
-          ./render_edgeclusters.sh
-          sleep 3
-        else
-          echo "Render Edge-cluster: Mock mode on"
-        fi
-
     - name: deploy-edgeclusters
       image: "$(params.ztp-container-image)"
       imagePullPolicy: Always
@@ -62,8 +36,13 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          cd ${WORKDIR}/${DEPLOY_EDGECLUSTERS_DIR}
-          ./deploy.sh
+          ztp create clusters \
+          --config "$(params.edgeclusters-config)" \
+          --output "/workspace/ztp/$(params.pipeline-name)" \
+          --mute \
+          --log-file "stdout" \
+          --log-level "$(params.ztp-log-level)" \
+          --wait "2h30m"
         else
           echo "Deploy Edge-cluster: Mock mode on"
         fi


### PR DESCRIPTION
# Description

This patch changes the `deploy-edgecluster` step of the pipeline so that it executes the `ztp` binary instead of shell scripts.

Related: https://issues.redhat.com/browse/MGMT-13114

Fixes MGMT-13114.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
