### PR TITLE
NO-ISSUE: Fix parsing IPs of agents

### DIFF
--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -529,7 +529,7 @@ func (e *Enricher) setExternalIPs(ctx context.Context, config *models.Config,
 	}
 
 	// Find the IP address for each external interface:
-	for i, node := range cluster.Nodes {
+	for _, node := range cluster.Nodes {
 		if node.ExternalNIC.IP != nil {
 			continue
 		}
@@ -543,7 +543,10 @@ func (e *Enricher) setExternalIPs(ctx context.Context, config *models.Config,
 				"mac", mac,
 				"ip", ip,
 			)
-			cluster.Nodes[i].ExternalNIC.IP = net.ParseIP(ip)
+			node.ExternalNIC.IP, _, err = net.ParseCIDR(ip)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -712,7 +712,7 @@ var _ = Describe("Enricher", Ordered, func() {
 					    - flags: []
 					      macAddress: a2:87:c3:6d:61:d{{ . }}
 					      ipV4Addresses:
-					      - 192.168.150.10{{ . }}
+					      - 192.168.150.10{{ . }}/24
 					      ipV6Addresses: []
 					{{ end }}
 				`),


### PR DESCRIPTION
# Description

Currently the enricher assumes that the IP addresses extracted from agents are something like `192.168.150.101` but they are like `192.168.150.101/24`. As a result they aren't detected correctly. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
