### PR TITLE
NO-ISSUE: Avoid log package interferences with tests

### DIFF
--- a/ztp/internal/cmd/suite_test.go
+++ b/ztp/internal/cmd/suite_test.go
@@ -15,6 +15,7 @@ License.
 package cmd
 
 import (
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -25,3 +26,7 @@ func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Commands")
 }
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(GinkgoWriter)
+})

--- a/ztp/internal/logging/suite_test.go
+++ b/ztp/internal/logging/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -28,6 +29,10 @@ func TestLogging(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Logging")
 }
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(GinkgoWriter)
+})
 
 // Parse parses a set of log lines into a slice of maps that is easier to analyze.
 func Parse(buffer io.Reader) []map[string]any {

--- a/ztp/internal/models/suite_test.go
+++ b/ztp/internal/models/suite_test.go
@@ -15,6 +15,7 @@ License.
 package models
 
 import (
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -25,3 +26,7 @@ func TestModels(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Models")
 }
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(GinkgoWriter)
+})

--- a/ztp/internal/suite_test.go
+++ b/ztp/internal/suite_test.go
@@ -15,6 +15,7 @@ License.
 package internal
 
 import (
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -25,3 +26,7 @@ func TestInternal(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Internal")
 }
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(GinkgoWriter)
+})

--- a/ztp/internal/templating/suite_test.go
+++ b/ztp/internal/templating/suite_test.go
@@ -15,6 +15,7 @@ License.
 package templating
 
 import (
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -25,3 +26,7 @@ func TestTemplating(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Templating")
 }
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(GinkgoWriter)
+})


### PR DESCRIPTION
# Description

This patch changes the tests so that it redirect the `log` package to the `GinkgoWriter` to avoid interferences of logs generated by the http package.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
