### PR TITLE
NO-ISSUE: Add shared code to setup config flags

### DIFF
--- a/ztp/internal/applier.go
+++ b/ztp/internal/applier.go
@@ -220,12 +220,12 @@ func (b *ApplierBuilder) Build() (result *Applier, err error) {
 		return
 	}
 
-	// Create the JQ object:
+	// Create the jq tool:
 	jq, err := jq.NewTool().
 		SetLogger(b.logger).
 		Build()
 	if err != nil {
-		err = fmt.Errorf("failed to create JQ object: %v", err)
+		err = fmt.Errorf("failed to create jq tool: %v", err)
 		return
 	}
 

--- a/ztp/internal/config/flags.go
+++ b/ztp/internal/config/flags.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package config
+
+import "github.com/spf13/pflag"
+
+// AddFlags adds the flags related to configuration to the given flag set.
+func AddFlags(set *pflag.FlagSet) {
+	set.StringP(
+		configFlagName,
+		"c",
+		"",
+		"If this is the name of a file with extension '.yaml' or '.yml' then the "+
+			"configuration text will be loaded from that file. Otherwise the "+
+			"value should be the YAML text itself.",
+	)
+}
+
+// Names of the flags:
+const (
+	configFlagName = "config"
+)

--- a/ztp/internal/enricher.go
+++ b/ztp/internal/enricher.go
@@ -90,7 +90,7 @@ func (b *EnricherBuilder) Build() (result *Enricher, err error) {
 		return
 	}
 
-	// Create the JQ object:
+	// Create the jq tool:
 	jq, err := jq.NewTool().
 		SetLogger(b.logger).
 		Build()

--- a/ztp/internal/jq/tool.go
+++ b/ztp/internal/jq/tool.go
@@ -65,22 +65,22 @@ func (b *ToolBuilder) Build() (result *Tool, err error) {
 // Query the given query on the given input data and stores the result into the given output
 // variable. An error will be returned if the query can't be parsed or if the data doesn't fit into
 // the output variable.
-func (j *Tool) Query(query string, input any, output any) error {
+func (t *Tool) Query(query string, input any, output any) error {
 	inputBytes, err := json.Marshal(input)
 	if err != nil {
 		return fmt.Errorf("failed to marshal input: %v", err)
 	}
-	return j.QueryBytes(query, inputBytes, output)
+	return t.QueryBytes(query, inputBytes, output)
 }
 
 // QueryString is similar to Query, but it expects an input string containing JSON text.
-func (j *Tool) QueryString(query string, input string, output any) error {
-	return j.QueryBytes(query, []byte(input), output)
+func (t *Tool) QueryString(query string, input string, output any) error {
+	return t.QueryBytes(query, []byte(input), output)
 }
 
 // QueryBytes is similar to Query, but it expects as input an array of bytes containing the JSON
 // text.
-func (j *Tool) QueryBytes(query string, input []byte, output any) error {
+func (t *Tool) QueryBytes(query string, input []byte, output any) error {
 	// Check that the output is a pointer:
 	outputValue := reflect.ValueOf(output)
 	if outputValue.Kind() != reflect.Pointer {


### PR DESCRIPTION
# Description

Currently every command that needs the `--config` flag declares it separately. To avoid that repetition this patch moves that logic to a new `config.AddFlags` function.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
