### PR TITLE
NO-ISSUE: Don't explicitly delete cluster deployments

### DIFF
--- a/ztp/internal/applier.go
+++ b/ztp/internal/applier.go
@@ -302,18 +302,21 @@ func (b *ApplierBuilder) findTemplates(fsys fs.FS) (results []string, err error)
 
 // Apply generates the objects passing the given data to the templates and then creates them.
 func (a *Applier) Apply(ctx context.Context, data any) error {
-	// Render the objects:
 	objects, err := a.Render(ctx, data)
 	if err != nil {
 		return err
 	}
+	return a.applyObjects(ctx, objects)
+}
 
+// ApplyObjects creates the given objects.
+func (a *Applier) ApplyObjects(ctx context.Context, objects []*unstructured.Unstructured) error {
 	// Namespaces and custom resource definitions need to be created first as other objects will
 	// depend on them, so first we need to classify the rendered objects.
 	namespaces, crds, others := a.classifyObjects(objects)
 
 	// Create the namespaces:
-	err = a.applyNamespaces(ctx, namespaces)
+	err := a.applyNamespaces(ctx, namespaces)
 	if err != nil {
 		return err
 	}
@@ -333,14 +336,17 @@ func (a *Applier) Apply(ctx context.Context, data any) error {
 	return nil
 }
 
-// Delete generates the objects passing the gien data to the templates and then deletes them.
+// Delete generates the objects passing the given data to the templates and then deletes them.
 func (a *Applier) Delete(ctx context.Context, data any) error {
-	// Render the objects:
 	objects, err := a.Render(ctx, data)
 	if err != nil {
 		return err
 	}
+	return a.DeleteObjects(ctx, objects)
+}
 
+// DeleteObjects deletes the given objects.
+func (a *Applier) DeleteObjects(ctx context.Context, objects []*unstructured.Unstructured) error {
 	// Templates are usually in a logical creation order and we want to use the reverse order
 	// for deletion:
 	for i, j := 0, len(objects)-1; i < j; i, j = i+1, j-1 {
@@ -354,7 +360,7 @@ func (a *Applier) Delete(ctx context.Context, data any) error {
 	namespaces, crds, others := a.classifyObjects(objects)
 
 	// Delete the regular objects:
-	err = a.deleteObjects(ctx, others)
+	err := a.deleteObjects(ctx, others)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Currently the `delete cluster` command deletes all the objects that `clreate cluster` creates. But the Hive cluster deployment can't be deleted because then Hive automatically deletes the namespace it contains. As a result the bare metal hosts can't be deleted successfully because the deletion process needs to create other objects inside the (now gone) namespace. To address that this patch changes the `delete cluster` command so that it doesn't delete the cluster deployment; it will be deleted automatically when the namespace is deleted.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
