### PR TITLE
NO-ISSUE: Stop waiting when cluster installation fails

### DIFF
--- a/ztp/internal/cmd/create_cluster_cmd_test.go
+++ b/ztp/internal/cmd/create_cluster_cmd_test.go
@@ -455,7 +455,10 @@ var _ = Describe("Create cluster command", Ordered, func() {
 
 		// Check that the tool has written the message that indicates that the cluster
 		// completed the installation:
-		Expect(buffer.String()).To(ContainSubstring("Cluster '%s' is installed", name))
+		Expect(buffer.String()).To(ContainSubstring(
+			"Installation of cluster '%s' succeeded",
+			name,
+		))
 	})
 
 	It("Writes the states as the installation progresses", func() {
@@ -597,5 +600,134 @@ var _ = Describe("Create cluster command", Ordered, func() {
 
 		// Check that the tool has written the message that indicate the changes of state:
 		Expect(buffer.String()).To(ContainSubstring("Cluster '%s' moved to state 'my-state'", name))
+	})
+
+	It("Stops if the cluster installation fails", func() {
+		// Prepare the configuration:
+		config := Template(
+			Dedent(`
+				config:
+				  OC_OCP_VERSION: '4.11.20'
+				  OC_ACM_VERSION: '2.6'
+				  OC_ODF_VERSION: '4.11'
+				edgeclusters:
+				- {{ .Name }}:
+				    config:
+				      tpm: false
+				    contrib:
+				      gpu-operator:
+				        version: "v1.10.1"
+				    master0:
+				      nic_ext_dhcp: enp1s0
+				      mac_ext_dhcp: "63:ed:8b:f1:15:4c"
+				      bmc_url: "redfish-virtualmedia+http://192.168.122.1:8000/redfish/v1/Systems/d5405874-a05e-44bd-a6e1-f7105d6ed932"
+				      bmc_user: "user0"
+				      bmc_pass: "pass0"
+				      root_disk: /dev/vda
+				      storage_disk:
+				      - /dev/vdb
+			`),
+			"Name", name,
+		)
+
+		// Remember to delete the cluster when done:
+		defer func() {
+			tool, err := internal.NewTool().
+				SetLogger(logger).
+				SetArgs(
+					"ztp", "delete", "cluster",
+					"--config", config,
+					"--resolver", dns.Address(),
+				).
+				AddCommand(deletecmd.Cobra).
+				SetIn(&bytes.Buffer{}).
+				SetOut(GinkgoWriter).
+				SetErr(GinkgoWriter).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = tool.Run(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// Run the command to create the cluster in a separate goroutine:
+		buffer := &bytes.Buffer{}
+		multi := io.MultiWriter(buffer, GinkgoWriter)
+		finished := &atomic.Bool{}
+		go func() {
+			defer GinkgoRecover()
+			tool, err := internal.NewTool().
+				SetLogger(logger).
+				SetArgs(
+					"ztp", "create", "cluster",
+					"--config", config,
+					"--resolver", dns.Address(),
+					"--wait", "1m",
+				).
+				AddCommand(createcmd.Cobra).
+				SetIn(&bytes.Buffer{}).
+				SetOut(multi).
+				SetErr(multi).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			err = tool.Run(ctx)
+			Expect(err).To(HaveOccurred())
+			finished.Store(true)
+		}()
+
+		// Wait till the bare metal host exists, and then set the state to provisioned:
+		bmhObject := &unstructured.Unstructured{}
+		bmhObject.SetGroupVersionKind(internal.BareMetalHostGVK)
+		bmhKey := clnt.ObjectKey{
+			Namespace: name,
+			Name:      fmt.Sprintf("ztpfw-%s-master-0", name),
+		}
+		Eventually(func() error {
+			return client.Get(ctx, bmhKey, bmhObject)
+		}, time.Minute).Should(Succeed())
+		bmhUpdate := bmhObject.DeepCopy()
+		bmhUpdate.Object["status"] = map[string]any{
+			"provisioning": map[string]any{
+				"ID":    uuid.NewString(),
+				"state": "provisioned",
+			},
+			"errorMessage":      "my-error",
+			"hardwareProfile":   "my-profile",
+			"operationalStatus": "OK",
+			"poweredOn":         true,
+		}
+		err := client.Status().Patch(ctx, bmhUpdate, clnt.MergeFrom(bmhObject))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait till the agent cluster install exists and set it status to failed:
+		aciObject := &unstructured.Unstructured{}
+		aciObject.SetGroupVersionKind(internal.AgentClusterInstallGVK)
+		aciKey := clnt.ObjectKey{
+			Namespace: name,
+			Name:      name,
+		}
+		Eventually(func() error {
+			return client.Get(ctx, aciKey, aciObject)
+		}, time.Minute).Should(Succeed())
+		aciUpdate := aciObject.DeepCopy()
+		aciUpdate.Object["status"] = map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":   "Failed",
+					"status": "True",
+				},
+			},
+		}
+		err = client.Status().Patch(ctx, aciUpdate, clnt.MergeFrom(aciObject))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait till the tool finishes:
+		Eventually(finished.Load, time.Minute).Should(BeTrue())
+
+		// Check that the tool has written the message that indicates that the cluster
+		// installation failed:
+		Expect(buffer.String()).To(ContainSubstring(
+			"Installation of cluster '%s' failed",
+			name,
+		))
 	})
 })


### PR DESCRIPTION
# Description

Currently the `create cluster` commands waits for the cluster to be installed, but it doesn't stop waiting if the installation fails. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested with the included tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
