### PR TITLE
NO-ISSUE: Add internal IP to `br-ex`

### DIFF
--- a/ztp/internal/data/cluster/files/add-internal-ip-bmh.sh
+++ b/ztp/internal/data/cluster/files/add-internal-ip-bmh.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/bash
 
 # This script will only be present in nodes that don't have an internal NIC. For those nodes we need
-# to add the internal IP to the external NIC.
-external_dev="{{ .ExternalNIC.Name }}"
+# to add the internal IP to the external `br-ex` bridge used by OVS:
 internal_ip="{{ .InternalIP }}"
-nmcli connection modify "${external_dev}" +ipv4.addresses "${internal_ip}" ipv4.method auto
-ip addr add "${internal_ip}" dev "${external_dev}"
+nmcli connection modify br-ex +ipv4.addresses "${internal_ip}" ipv4.method auto
+ip addr add "${internal_ip}" dev br-ex


### PR DESCRIPTION
# Description

Currently one a node has only one NIC we add the internal IP address to the external NIC, but that doesn't work correctly: it needs to be added to the `br-ex` bridge that is used by OVS.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
