### PR TITLE
NO-ISSUE: Fix assignment of API and ingress addresses

### DIFF
--- a/ztp/internal/data/cluster/files/api_hosts
+++ b/ztp/internal/data/cluster/files/api_hosts
@@ -1,1 +1,1 @@
-192.168.7.243 api.{{ .Cluster.Name }}.{{ .Cluster.DNS.Domain }}
+{{ .Cluster.API.InternalIP }} api.{{ .Cluster.Name }}.{{ .Cluster.DNS.Domain }}

--- a/ztp/internal/data/cluster/objects/030-agentclusterinstall.yaml
+++ b/ztp/internal/data/cluster/objects/030-agentclusterinstall.yaml
@@ -19,8 +19,8 @@ spec:
   {{ end}}
 
   {{ if not .Cluster.SNO }}
-  apiVIP: {{ .Cluster.API.VIP }}
-  ingressVIP: {{ .Cluster.Ingress.VIP }}
+  apiVIP: {{ .Cluster.API.InternalIP }}
+  ingressVIP: {{ .Cluster.Ingress.InternalIP }}
   networking:
     networkType: OVNKubernetes
     clusterNetwork:

--- a/ztp/internal/data/metallb/objects/0100-metallb-api-ipaddresspool.yaml
+++ b/ztp/internal/data/metallb/objects/0100-metallb-api-ipaddresspool.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   autoAssign: false
   addresses:
-  - {{ .Cluster.API.IP }}/32
+  - {{ .Cluster.API.ExternalIP }}/32

--- a/ztp/internal/data/metallb/objects/0120-metallb-ingress-ipaddresspool.yaml
+++ b/ztp/internal/data/metallb/objects/0120-metallb-ingress-ipaddresspool.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   autoAssign: false
   addresses:
-  - {{ .Cluster.Ingress.IP }}/32
+  - {{ .Cluster.Ingress.ExternalIP }}/32

--- a/ztp/internal/enricher_test.go
+++ b/ztp/internal/enricher_test.go
@@ -563,8 +563,8 @@ var _ = Describe("Enricher", Ordered, func() {
 			Expect(cluster.Nodes[1].InternalIP.String()).To(Equal("192.168.7.11/24"))
 			Expect(cluster.Nodes[2].InternalIP.String()).To(Equal("192.168.7.12/24"))
 			Expect(cluster.Nodes[3].InternalIP.String()).To(Equal("192.168.7.13/24"))
-			Expect(cluster.API.VIP).To(Equal("192.168.7.242"))
-			Expect(cluster.Ingress.VIP).To(Equal("192.168.7.243"))
+			Expect(cluster.Ingress.InternalIP.String()).To(Equal("192.168.7.242"))
+			Expect(cluster.API.InternalIP.String()).To(Equal("192.168.7.243"))
 		})
 
 		It("Sets the hardcoded internal IP addresses for SNO", func() {
@@ -592,8 +592,8 @@ var _ = Describe("Enricher", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			cluster := config.Clusters[0]
 			Expect(cluster.Nodes[0].InternalIP.String()).To(Equal("192.168.7.10/24"))
-			Expect(cluster.API.VIP).To(BeEmpty())
-			Expect(cluster.Ingress.VIP).To(BeEmpty())
+			Expect(cluster.Ingress.InternalIP.String()).To(Equal("192.168.7.242"))
+			Expect(cluster.API.InternalIP.String()).To(Equal("192.168.7.243"))
 		})
 
 		It("Doesn't change the SSH keys if already set", func() {
@@ -922,8 +922,8 @@ var _ = Describe("Enricher", Ordered, func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			defer conn.Close()
-			Expect(cluster.API.IP).To(Equal("192.168.150.100"))
-			Expect(cluster.Ingress.IP).To(Equal("192.168.150.101"))
+			Expect(cluster.API.ExternalIP.String()).To(Equal("192.168.150.100"))
+			Expect(cluster.Ingress.ExternalIP.String()).To(Equal("192.168.150.101"))
 		})
 	})
 })

--- a/ztp/internal/models/api.go
+++ b/ztp/internal/models/api.go
@@ -14,7 +14,9 @@ License.
 
 package models
 
+import "net"
+
 type API struct {
-	VIP string
-	IP  string
+	InternalIP net.IP
+	ExternalIP net.IP
 }

--- a/ztp/internal/models/ingress.go
+++ b/ztp/internal/models/ingress.go
@@ -14,7 +14,9 @@ License.
 
 package models
 
+import "net"
+
 type Ingress struct {
-	VIP string
-	IP  string
+	InternalIP net.IP
+	ExternalIP net.IP
 }


### PR DESCRIPTION
# Description

The internal ingress address is 192.168.7.242 and the internal API address is 192.168.7.243, but the CLI is using them swapped. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
