### PR TITLE
NO-ISSUE: Route via hosts

### DIFF
--- a/ztp/internal/data/cluster/files/cluster-network-03-config.yml
+++ b/ztp/internal/data/cluster/files/cluster-network-03-config.yml
@@ -1,0 +1,9 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+        routingViaHost: true

--- a/ztp/internal/data/cluster/objects/020-manifests-configmap.yaml
+++ b/ztp/internal/data/cluster/objects/020-manifests-configmap.yaml
@@ -7,3 +7,4 @@ metadata:
     manifests-directory: manifests
 data:
   node-ip-config.yml: {{ execute "files/node-ip-config.yaml" . | json }}
+  cluster-network-03-config.yml: {{ execute "files/cluster-network-03-config.yml" . | json }}


### PR DESCRIPTION
# Description

This patch changes the `created edgecluster` command so that it sets the `routingViaHost: true` parameter using the installer configuration overriding mechanism. This parameter is needed later by the `create metallb` command, and it is also needed when the hosts only have one NIC.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
