### PR TITLE
NO-ISSUE: Add support for custom log fields

### DIFF
--- a/ztp/internal/logging/flags.go
+++ b/ztp/internal/logging/flags.go
@@ -30,13 +30,33 @@ func AddFlags(set *pflag.FlagSet) {
 		"",
 		"Log file. The default is to write to a 'ztp.log' file inside the user cache "+
 			"directory. The value can also be 'stdout' or 'stderr' and then the "+
-			"log will be written to the standard output or error streams of the "+
+			"log will be written to the standard output or error stream of the "+
 			"process.",
+	)
+	_ = set.StringArray(
+		fieldFlagName,
+		[]string{},
+		"Feld to add to all log messages. The value can be a percent sign followed by "+
+			"one of the letters that indicate a special value, or a field name "+
+			"followed by an equals sign and the field value. For example '%p' "+
+			"results in a field named 'pid' containing the identifier of the "+
+			"process, and 'my-field=my-value' results in adding a field named "+
+			"'my-field' with value 'my-value'.",
+	)
+	_ = set.StringSlice(
+		fieldsFlagName,
+		[]string{},
+		"Comma separated list of fields to add to all log messages. See the "+
+			"'--log-field' option for details of allowed values. Note that "+
+			"this doesn't allow values containing commas, use the '--log-field' "+
+			"option if you need that.",
 	)
 }
 
 // Names of the flags:
 const (
-	levelFlagName = "log-level"
-	fileFlagName  = "log-file"
+	levelFlagName  = "log-level"
+	fileFlagName   = "log-file"
+	fieldFlagName  = "log-field"
+	fieldsFlagName = "log-fields"
 )

--- a/ztp/internal/logging/transport_wrapper.go
+++ b/ztp/internal/logging/transport_wrapper.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/spf13/pflag"
 )
 
 // TransportWrapperBuilder contains the data and logic needed to build a transport wrapper that
@@ -89,6 +90,12 @@ func (b *TransportWrapperBuilder) SetHeaderLevel(value int) *TransportWrapperBui
 // Default is two.
 func (b *TransportWrapperBuilder) SetBodyLevel(value int) *TransportWrapperBuilder {
 	b.bodyLevel = value
+	return b
+}
+
+// SetFlags sets the command line flags that should be used to configure the logger. This is
+// optional.
+func (b *TransportWrapperBuilder) SetFlags(flags *pflag.FlagSet) *TransportWrapperBuilder {
 	return b
 }
 


### PR DESCRIPTION
# Description

This patch adds command line options that add custom log fields. For example, to add a field with name `user` containing the user name:

```
$ ztp create cluster -c my-config.yaml --log-field "user=${USER}"
```

This is intended for situations where multiple processes write to the same file. Adding these fields it is easier to identify which process is the one that wrote a particular log message. In that context it is specially useful to add the PID of the proccess. The special value `%p` is used for that:

```
$ ztp create cluster -c my-config.yaml --log-field pid=%p
```

Or just `%p`, without the `pid=` prefix:

```
$ ztp create cluster -c my-config.yaml --log-field %p
```

Note that before this patch the `pid` field was always added, now it isn't added by default.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
