### PR TITLE
NO-ISSUE: Add options to enable/disable HTTP logging

### DIFF
--- a/ztp/internal/client.go
+++ b/ztp/internal/client.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,6 +47,7 @@ type ClientBuilder struct {
 	sshServers []string
 	sshUser    string
 	sshKey     []byte
+	flags      *pflag.FlagSet
 }
 
 // Client is an implementtion of the controller-runtime WithWatch interface with additional
@@ -122,6 +124,13 @@ func (b *ClientBuilder) SetSSHUser(value string) *ClientBuilder {
 // be a PEM encoded private key.
 func (b *ClientBuilder) SetSSHKey(value []byte) *ClientBuilder {
 	b.sshKey = value
+	return b
+}
+
+// SetFlags sets the command line flags that should be used to configure the client. This is
+// optional.
+func (b *ClientBuilder) SetFlags(flags *pflag.FlagSet) *ClientBuilder {
+	b.flags = flags
 	return b
 }
 
@@ -206,6 +215,7 @@ func (b *ClientBuilder) loadConfig() (result *rest.Config, err error) {
 	// the log:
 	loggingWrapper, err := logging.NewTransportWrapper().
 		SetLogger(b.logger).
+		SetFlags(b.flags).
 		Build()
 	if err != nil {
 		return

--- a/ztp/internal/client_test.go
+++ b/ztp/internal/client_test.go
@@ -113,24 +113,17 @@ var _ = Describe("Client", func() {
 		}
 		var message Message
 
-		// The first message should contain the details of the request header:
+		// The first message should contain the details of the request:
 		err = json.Unmarshal([]byte(lines[0]), &message)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(message.Msg).To(Equal("Sending request header"))
+		Expect(message.Msg).To(Equal("Sending request"))
 		Expect(message.Method).To(Equal("GET"))
 		Expect(message.URL).To(MatchRegexp("^https://.*/api/v1/pods$"))
 
-		// The second message should contain the details of the response header:
+		// The second message should contain the details of the response:
 		err = json.Unmarshal([]byte(lines[1]), &message)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(message.Msg).To(Equal("Received response header"))
+		Expect(message.Msg).To(Equal("Received response"))
 		Expect(message.Code).To(Equal(200))
-
-		// The third message should contain the details of the response body:
-		err = json.Unmarshal([]byte(lines[2]), &message)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(message.Msg).To(Equal("Received response body"))
-		Expect(message.Code).To(Equal(200))
-		Expect(message.N).To(BeNumerically(">", 0))
 	})
 })

--- a/ztp/internal/cmd/delete/cluster/delete_cluster_cmd.go
+++ b/ztp/internal/cmd/delete/cluster/delete_cluster_cmd.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
@@ -47,6 +48,7 @@ func Cobra() *cobra.Command {
 // Command contains the data and logic needed to run the `delete cluster` command.
 type Command struct {
 	logger  logr.Logger
+	flags   *pflag.FlagSet
 	console *internal.Console
 	config  *models.Config
 	client  *internal.Client
@@ -69,6 +71,9 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	c.logger = internal.LoggerFromContext(ctx)
 	c.console = internal.ConsoleFromContext(ctx)
 
+	// Save the flags:
+	c.flags = cmd.Flags()
+
 	// Load the configuration:
 	c.config, err = config.NewLoader().
 		SetLogger(c.logger).
@@ -85,6 +90,7 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 	// Create the client for the API:
 	c.client, err = internal.NewClient().
 		SetLogger(c.logger).
+		SetFlags(c.flags).
 		Build()
 	if err != nil {
 		c.console.Error(

--- a/ztp/internal/cmd/dev/apply/dev_apply_cmd.go
+++ b/ztp/internal/cmd/dev/apply/dev_apply_cmd.go
@@ -74,6 +74,9 @@ func (c *Command) run(cmd *cobra.Command, argv []string) error {
 	tool := internal.ToolFromContext(ctx)
 	console := internal.ConsoleFromContext(ctx)
 
+	// Get the flags:
+	flags := cmd.Flags()
+
 	// Create a temporary directory where we can copy all the input files to pass them to the
 	// applier:
 	tmp, err := os.MkdirTemp("", "*.ztp")
@@ -126,6 +129,7 @@ func (c *Command) run(cmd *cobra.Command, argv []string) error {
 	// Create the client for the API:
 	client, err := internal.NewClient().
 		SetLogger(logger).
+		SetFlags(flags).
 		Build()
 	if err != nil {
 		console.Error(

--- a/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
+++ b/ztp/internal/cmd/dev/cleanup/dev_cleanup_cmd.go
@@ -51,9 +51,13 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 	logger := internal.LoggerFromContext(ctx)
 	console := internal.ConsoleFromContext(ctx)
 
+	// Get the flags:
+	flags := cmd.Flags()
+
 	// Create the client for the API:
 	client, err := internal.NewClient().
 		SetLogger(logger).
+		SetFlags(flags).
 		Build()
 	if err != nil {
 		console.Error(

--- a/ztp/internal/cmd/dev/delete/dev_delete_cmd.go
+++ b/ztp/internal/cmd/dev/delete/dev_delete_cmd.go
@@ -74,6 +74,9 @@ func (c *Command) run(cmd *cobra.Command, argv []string) error {
 	tool := internal.ToolFromContext(ctx)
 	console := internal.ConsoleFromContext(ctx)
 
+	// Get te flags:
+	flags := cmd.Flags()
+
 	// Create a temporary directory where we can copy all the input files to pass them to the
 	// applier:
 	tmp, err := os.MkdirTemp("", "*.ztp")
@@ -126,6 +129,7 @@ func (c *Command) run(cmd *cobra.Command, argv []string) error {
 	// Create the client for the API:
 	client, err := internal.NewClient().
 		SetLogger(logger).
+		SetFlags(flags).
 		Build()
 	if err != nil {
 		console.Error(

--- a/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
+++ b/ztp/internal/cmd/dev/setup/dev_setup_cmd.go
@@ -52,9 +52,13 @@ func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
 	logger := internal.LoggerFromContext(ctx)
 	console := internal.ConsoleFromContext(ctx)
 
+	// Get the flags:
+	flags := cmd.Flags()
+
 	// Create the client for the API:
 	client, err := internal.NewClient().
 		SetLogger(logger).
+		SetFlags(flags).
 		Build()
 	if err != nil {
 		console.Error(

--- a/ztp/internal/logging/flags.go
+++ b/ztp/internal/logging/flags.go
@@ -51,12 +51,25 @@ func AddFlags(set *pflag.FlagSet) {
 			"this doesn't allow values containing commas, use the '--log-field' "+
 			"option if you need that.",
 	)
+	_ = set.Bool(
+		headersFlagName,
+		false,
+		"Include HTTP headers in log messages.",
+	)
+	_ = set.Bool(
+		bodiesFlagName,
+		false,
+		"Include details of HTTP request and response bodies in log messages. Note "+
+			"that currently only the size is written, not the complete body.",
+	)
 }
 
 // Names of the flags:
 const (
-	levelFlagName  = "log-level"
-	fileFlagName   = "log-file"
-	fieldFlagName  = "log-field"
-	fieldsFlagName = "log-fields"
+	levelFlagName   = "log-level"
+	fileFlagName    = "log-file"
+	fieldFlagName   = "log-field"
+	fieldsFlagName  = "log-fields"
+	headersFlagName = "log-headers"
+	bodiesFlagName  = "log-bodies"
 )

--- a/ztp/internal/logging/logger.go
+++ b/ztp/internal/logging/logger.go
@@ -122,30 +122,32 @@ func (b *LoggerBuilder) SetFile(value string) *LoggerBuilder {
 // SetFlags sets the command line flags that should be used to configure the logger. This is
 // optional.
 func (b *LoggerBuilder) SetFlags(flags *pflag.FlagSet) *LoggerBuilder {
-	if flags.Changed(levelFlagName) {
-		value, err := flags.GetInt(levelFlagName)
-		if err == nil {
-			b.SetLevel(value)
+	if flags != nil {
+		if flags.Changed(levelFlagName) {
+			value, err := flags.GetInt(levelFlagName)
+			if err == nil {
+				b.SetLevel(value)
+			}
 		}
-	}
-	if flags.Changed(fileFlagName) {
-		value, err := flags.GetString(fileFlagName)
-		if err == nil {
-			b.SetFile(value)
+		if flags.Changed(fileFlagName) {
+			value, err := flags.GetString(fileFlagName)
+			if err == nil {
+				b.SetFile(value)
+			}
 		}
-	}
-	if flags.Changed(fieldFlagName) {
-		values, err := flags.GetStringArray(fieldFlagName)
-		if err == nil {
-			fields := b.parseFieldItems(values)
-			b.AddFields(fields)
+		if flags.Changed(fieldFlagName) {
+			values, err := flags.GetStringArray(fieldFlagName)
+			if err == nil {
+				fields := b.parseFieldItems(values)
+				b.AddFields(fields)
+			}
 		}
-	}
-	if flags.Changed(fieldsFlagName) {
-		values, err := flags.GetStringSlice(fieldsFlagName)
-		if err == nil {
-			fields := b.parseFieldItems(values)
-			b.AddFields(fields)
+		if flags.Changed(fieldsFlagName) {
+			values, err := flags.GetStringSlice(fieldsFlagName)
+			if err == nil {
+				fields := b.parseFieldItems(values)
+				b.AddFields(fields)
+			}
 		}
 	}
 	return b

--- a/ztp/internal/logging/transport_wrapper_test.go
+++ b/ztp/internal/logging/transport_wrapper_test.go
@@ -21,9 +21,12 @@ import (
 	"math"
 	"net/http"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/ghttp"
+	"github.com/spf13/pflag"
 )
 
 var _ = Describe("Transport wrapper", func() {
@@ -36,81 +39,27 @@ var _ = Describe("Transport wrapper", func() {
 		Expect(wrapper).To(BeNil())
 	})
 
-	It("Can't be created with negative header level", func() {
-		// Create the logger:
-		logger, err := NewLogger().
-			SetWriter(io.Discard).
-			SetLevel(math.MaxInt).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-
-		// Try to create the wrapper:
-		wrapper, err := NewTransportWrapper().
-			SetLogger(logger).
-			SetHeaderLevel(-1).
-			Build()
-		Expect(err).To(HaveOccurred())
-		msg := err.Error()
-		Expect(msg).To(ContainSubstring("header"))
-		Expect(msg).To(ContainSubstring("-1"))
-		Expect(msg).To(ContainSubstring("must be greater than or equal to 0"))
-		Expect(wrapper).To(BeNil())
-	})
-
-	It("Can't be created with negative body level", func() {
-		// Create the logger:
-		logger, err := NewLogger().
-			SetWriter(io.Discard).
-			SetLevel(math.MaxInt).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-
-		// Try to create the wrapper:
-		wrapper, err := NewTransportWrapper().
-			SetLogger(logger).
-			SetBodyLevel(-1).
-			Build()
-		Expect(err).To(HaveOccurred())
-		msg := err.Error()
-		Expect(msg).To(ContainSubstring("body"))
-		Expect(msg).To(ContainSubstring("-1"))
-		Expect(msg).To(ContainSubstring("must be greater than or equal to 0"))
-		Expect(wrapper).To(BeNil())
-	})
-
 	Context("With server", func() {
 		var (
 			server *Server
 			buffer *bytes.Buffer
-			client *http.Client
+			logger logr.Logger
 		)
 
 		BeforeEach(func() {
+			var err error
+
 			// Create the server:
 			server = NewServer()
 
 			// Create a logger that writes to the Ginkgo writer and also a buffer in
 			// memory, so that we can analyze the result:
 			buffer = &bytes.Buffer{}
-			logger, err := NewLogger().
+			logger, err = NewLogger().
 				SetWriter(io.MultiWriter(buffer, GinkgoWriter)).
 				SetLevel(math.MaxInt).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-
-			// Create the client:
-			wrapper, err := NewTransportWrapper().
-				SetLogger(logger).
-				SetHeaderLevel(15).
-				SetBodyLevel(16).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			transport := wrapper.Wrap(http.DefaultTransport)
-
-			// Create the client:
-			client = &http.Client{
-				Transport: transport,
-			}
 		})
 
 		AfterEach(func() {
@@ -122,6 +71,15 @@ var _ = Describe("Transport wrapper", func() {
 			// Prepare the server:
 			server.AppendHandlers(RespondWith(http.StatusOK, nil))
 
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
 			// Send the request:
 			url := fmt.Sprintf("%s/my-path", server.URL())
 			response, err := client.Get(url)
@@ -132,7 +90,7 @@ var _ = Describe("Transport wrapper", func() {
 
 			// Verify the request line details:
 			messages := Parse(buffer)
-			details := Find(messages, "Sending request header")
+			details := Find(messages, "Sending request")
 			Expect(details).To(HaveLen(1))
 			detail := details[0]
 			Expect(detail).To(HaveKeyWithValue("method", http.MethodGet))
@@ -142,6 +100,15 @@ var _ = Describe("Transport wrapper", func() {
 		It("Writes the details of the response line", func() {
 			// Prepare the server:
 			server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
 
 			// Send the request:
 			url := fmt.Sprintf("%s/my-path", server.URL())
@@ -153,96 +120,62 @@ var _ = Describe("Transport wrapper", func() {
 
 			// Verify the response line details:
 			messages := Parse(buffer)
-			details := Find(messages, "Received response header")
+			details := Find(messages, "Received response")
 			Expect(details).ToNot(BeEmpty())
 			detail := details[0]
-			Expect(detail).To(HaveKeyWithValue("protocol", "HTTP/1.1"))
-			Expect(detail).To(HaveKeyWithValue("status", "200 OK"))
 			Expect(detail).To(HaveKeyWithValue("code", BeNumerically("==", http.StatusOK)))
 		})
 
-		It("Writes the size of the request body chunks", func() {
+		It("Writes request headers if explicitly enabled", func() {
 			// Prepare the server:
 			server.AppendHandlers(RespondWith(http.StatusOK, nil))
 
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				SetHeaders(true).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
 			// Send the request:
 			url := fmt.Sprintf("%s/my-path", server.URL())
-			body := make([]byte, 42)
-			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+			request, err := http.NewRequest(http.MethodGet, url, nil)
+			Expect(err).ToNot(HaveOccurred())
+			request.Header.Set("My-Header", "my-value")
+			response, err := client.Do(request)
 			Expect(err).ToNot(HaveOccurred())
 			defer response.Body.Close()
 			_, err = io.Copy(io.Discard, response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify the number of bytes. Note that there may be multiple lines like
-			// this if the response body was split into multiple network packages, so we
-			// will sum the values of the `n` fields and count the total.
+			// Verify the response line details:
 			messages := Parse(buffer)
-			details := Find(messages, "Sending request body")
+			details := Find(messages, "Sending request")
 			Expect(details).ToNot(BeEmpty())
-			total := 0
-			for _, detail := range details {
-				Expect(detail).To(HaveKeyWithValue("n", BeNumerically(">=", 0)))
-				total += int(detail["n"].(float64))
-			}
-			Expect(total).To(Equal(len(body)))
+			detail := details[0]
+			Expect(detail).To(HaveKeyWithValue(
+				"headers", HaveKeyWithValue(
+					"My-Header", ConsistOf("my-value"),
+				),
+			))
 		})
 
-		It("Writes the size of the response body chunks", func() {
-			// Prepare the server:
-			body := make([]byte, 42)
-			server.AppendHandlers(RespondWith(http.StatusOK, body))
-
-			// Send the request:
-			url := fmt.Sprintf("%s/my-path", server.URL())
-			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
-			Expect(err).ToNot(HaveOccurred())
-			defer response.Body.Close()
-			_, err = io.Copy(io.Discard, response.Body)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Verify the number of bytes. Note that there may be multiple lines like
-			// this if the response body was split into multiple network packages, so we
-			// will sum the values of the `n` fields and count the total.
-			messages := Parse(buffer)
-			details := Find(messages, "Received response body")
-			Expect(details).ToNot(BeEmpty())
-			total := 0
-			for _, detail := range details {
-				Expect(detail).To(HaveKeyWithValue("n", BeNumerically(">=", 0)))
-				total += int(detail["n"].(float64))
-			}
-			Expect(total).To(Equal(len(body)))
-		})
-
-		It("Writes request and response identifier", func() {
-			// Prepare the server:
-			body := make([]byte, 42)
-			server.AppendHandlers(RespondWith(http.StatusOK, body))
-
-			// Send the request:
-			url := fmt.Sprintf("%s/my-path", server.URL())
-			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
-			Expect(err).ToNot(HaveOccurred())
-			defer response.Body.Close()
-			_, err = io.Copy(io.Discard, response.Body)
-			Expect(err).ToNot(HaveOccurred())
-
-			// All the messages should contain the same identifier:
-			messages := Parse(buffer)
-			Expect(messages).ToNot(BeEmpty())
-			first := messages[0]
-			Expect(first).To(HaveKey("id"))
-			id := first["id"]
-			Expect(id).ToNot(BeEmpty())
-			for i := 1; i < len(messages); i++ {
-				Expect(messages[i]).To(HaveKeyWithValue("id", id))
-			}
-		})
-
-		It("Honors the header level", func() {
+		It("Doesn't write request headers if explicitly disabled", func() {
 			// Prepare the server:
 			server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				SetHeaders(false).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
 
 			// Send the request:
 			url := fmt.Sprintf("%s/my-path", server.URL())
@@ -252,24 +185,151 @@ var _ = Describe("Transport wrapper", func() {
 			_, err = io.Copy(io.Discard, response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify the level:
+			// Verify the response line details:
 			messages := Parse(buffer)
-			Expect(messages).ToNot(BeEmpty())
-			requests := Find(messages, "Sending request header")
-			Expect(requests).ToNot(BeEmpty())
-			for _, message := range requests {
-				Expect(message).To(HaveKeyWithValue("v", BeNumerically("==", 15)))
-			}
-			responses := Find(messages, "Received response header")
-			for _, message := range responses {
-				Expect(message).To(HaveKeyWithValue("v", BeNumerically("==", 15)))
-			}
+			details := Find(messages, "Sending request")
+			Expect(details).ToNot(BeEmpty())
+			detail := details[0]
+			Expect(detail).ToNot(HaveKey("headers"))
 		})
 
-		It("Honors the body level", func() {
+		It("Doesn't write request headers by default", func() {
+			// Prepare the server:
+			server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
+			// Send the request:
+			url := fmt.Sprintf("%s/my-path", server.URL())
+			response, err := client.Get(url)
+			Expect(err).ToNot(HaveOccurred())
+			defer response.Body.Close()
+			_, err = io.Copy(io.Discard, response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the response line details:
+			messages := Parse(buffer)
+			details := Find(messages, "Sending request")
+			Expect(details).ToNot(BeEmpty())
+			detail := details[0]
+			Expect(detail).ToNot(HaveKey("headers"))
+		})
+
+		It("Writes the details of the request body if explicitly enabled", func() {
+			// Prepare the server:
+			server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				SetBodies(true).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
+			// Send the request:
+			url := fmt.Sprintf("%s/my-path", server.URL())
+			body := make([]byte, 42)
+			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+			Expect(err).ToNot(HaveOccurred())
+			defer response.Body.Close()
+			_, err = io.Copy(io.Discard, response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the number of bytes. Note that there may be multiple lines like
+			// this if the response body was split into multiple network packages, so we
+			// will sum the values of the `n` fields and count the total.
+			messages := Parse(buffer)
+			details := Find(messages, "Sending body")
+			Expect(details).ToNot(BeEmpty())
+			total := 0
+			for _, detail := range details {
+				Expect(detail).To(HaveKeyWithValue("n", BeNumerically(">=", 0)))
+				total += int(detail["n"].(float64))
+			}
+			Expect(total).To(Equal(len(body)))
+		})
+
+		It("Doesn't write the details of the request body if explicitly disabled", func() {
+			// Prepare the server:
+			server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				SetBodies(false).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
+			// Send the request:
+			url := fmt.Sprintf("%s/my-path", server.URL())
+			body := make([]byte, 42)
+			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+			Expect(err).ToNot(HaveOccurred())
+			defer response.Body.Close()
+			_, err = io.Copy(io.Discard, response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that the details aren't written:
+			messages := Parse(buffer)
+			details := Find(messages, "Sending body")
+			Expect(details).To(BeEmpty())
+		})
+
+		It("Doesn't write the details of the request body by default", func() {
+			// Prepare the server:
+			server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
+			// Send the request:
+			url := fmt.Sprintf("%s/my-path", server.URL())
+			body := make([]byte, 42)
+			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+			Expect(err).ToNot(HaveOccurred())
+			defer response.Body.Close()
+			_, err = io.Copy(io.Discard, response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that the details aren't written:
+			messages := Parse(buffer)
+			details := Find(messages, "Sending body")
+			Expect(details).To(BeEmpty())
+		})
+
+		It("Writes the details of the response body if explicitly enabled", func() {
 			// Prepare the server:
 			body := make([]byte, 42)
 			server.AppendHandlers(RespondWith(http.StatusOK, body))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				SetBodies(true).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
 
 			// Send the request:
 			url := fmt.Sprintf("%s/my-path", server.URL())
@@ -279,17 +339,171 @@ var _ = Describe("Transport wrapper", func() {
 			_, err = io.Copy(io.Discard, response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify the level:
+			// Verify the number of bytes. Note that there may be multiple lines like
+			// this if the response body was split into multiple network packages, so we
+			// will sum the values of the `n` fields and count the total.
 			messages := Parse(buffer)
-			Expect(messages).ToNot(BeEmpty())
-			requests := Find(messages, "Sending request body")
-			for _, message := range requests {
-				Expect(message).To(HaveKeyWithValue("v", BeNumerically("==", 16)))
+			details := Find(messages, "Received body")
+			Expect(details).ToNot(BeEmpty())
+			total := 0
+			for _, detail := range details {
+				Expect(detail).To(HaveKeyWithValue("n", BeNumerically(">=", 0)))
+				total += int(detail["n"].(float64))
 			}
-			responses := Find(messages, "Received response body")
-			for _, message := range responses {
-				Expect(message).To(HaveKeyWithValue("v", BeNumerically("==", 16)))
-			}
+			Expect(total).To(Equal(len(body)))
 		})
+
+		It("Doesn't write the details of the response body if explicitly disabled", func() {
+			// Prepare the server:
+			body := make([]byte, 42)
+			server.AppendHandlers(RespondWith(http.StatusOK, body))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				SetBodies(false).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
+			// Send the request:
+			url := fmt.Sprintf("%s/my-path", server.URL())
+			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+			Expect(err).ToNot(HaveOccurred())
+			defer response.Body.Close()
+			_, err = io.Copy(io.Discard, response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that details aren't written:
+			messages := Parse(buffer)
+			details := Find(messages, "Received response body")
+			Expect(details).To(BeEmpty())
+		})
+
+		It("Doesn't write the details of the response body by default", func() {
+			// Prepare the server:
+			body := make([]byte, 42)
+			server.AppendHandlers(RespondWith(http.StatusOK, body))
+
+			// Create the client:
+			wrapper, err := NewTransportWrapper().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			client := &http.Client{
+				Transport: wrapper.Wrap(http.DefaultTransport),
+			}
+
+			// Send the request:
+			url := fmt.Sprintf("%s/my-path", server.URL())
+			response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+			Expect(err).ToNot(HaveOccurred())
+			defer response.Body.Close()
+			_, err = io.Copy(io.Discard, response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that details aren't written:
+			messages := Parse(buffer)
+			details := Find(messages, "Received response body")
+			Expect(details).To(BeEmpty())
+		})
+
+		DescribeTable(
+			"Honors the --log-headers flag",
+			func(expected bool, args ...string) {
+				// Prepare the server:
+				server.AppendHandlers(RespondWith(http.StatusOK, nil))
+
+				// Prepare the flags:
+				flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+				AddFlags(flags)
+				err := flags.Parse(args)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create the client:
+				wrapper, err := NewTransportWrapper().
+					SetLogger(logger).
+					SetFlags(flags).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				client := &http.Client{
+					Transport: wrapper.Wrap(http.DefaultTransport),
+				}
+
+				// Send the request:
+				url := fmt.Sprintf("%s/my-path", server.URL())
+				response, err := client.Get(url)
+				Expect(err).ToNot(HaveOccurred())
+				defer response.Body.Close()
+				_, err = io.Copy(io.Discard, response.Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify the response line details:
+				messages := Parse(buffer)
+				details := Find(messages, "Sending request")
+				Expect(details).ToNot(BeEmpty())
+				detail := details[0]
+				if expected {
+					Expect(detail).To(HaveKey("headers"))
+				} else {
+					Expect(detail).ToNot(HaveKey("headers"))
+				}
+			},
+			Entry("Disabled by default", false),
+			Entry("Explicitly enabled without value", true, "--log-headers"),
+			Entry("Explicitly enabled with value", true, "--log-headers=true"),
+			Entry("Explicitly disabled with value", false, "--log-headers=false"),
+		)
+
+		DescribeTable(
+			"Honors the --log-bodies flag",
+			func(expected bool, args ...string) {
+				// Prepare the server:
+				body := make([]byte, 42)
+				server.AppendHandlers(RespondWith(http.StatusOK, body))
+
+				// Prepare the flags:
+				flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+				AddFlags(flags)
+				err := flags.Parse(args)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create the client:
+				wrapper, err := NewTransportWrapper().
+					SetLogger(logger).
+					SetFlags(flags).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				client := &http.Client{
+					Transport: wrapper.Wrap(http.DefaultTransport),
+				}
+
+				// Send the request:
+				url := fmt.Sprintf("%s/my-path", server.URL())
+				response, err := client.Post(url, "application/octet-stream", bytes.NewBuffer(body))
+				Expect(err).ToNot(HaveOccurred())
+				defer response.Body.Close()
+				_, err = io.Copy(io.Discard, response.Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify that details aren't written:
+				messages := Parse(buffer)
+				requestDetails := Find(messages, "Received body")
+				responseDetails := Find(messages, "Received body")
+				if expected {
+					Expect(requestDetails).ToNot(BeEmpty())
+					Expect(responseDetails).ToNot(BeEmpty())
+				} else {
+					Expect(requestDetails).To(BeEmpty())
+					Expect(responseDetails).To(BeEmpty())
+				}
+			},
+			Entry("Disabled by default", false),
+			Entry("Explicitly enabled without value", true, "--log-bodies"),
+			Entry("Explicitly enabled with value", true, "--log-bodies=true"),
+			Entry("Explicitly disabled with value", false, "--log-bodies=false"),
+		)
 	})
 })


### PR DESCRIPTION
# Description

Currently when log level 2 is enabled we write to the log all the details of HTTP requests and responses, including HTTP headers and sizes of HTTP request and response bodies. This is quite noisy, and usually not necessary. This patch adds two new flags `--log-headers=[true|fase]` and `--log-bodies=[true|false]` that allow selectively enabling/disabling those details.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
