### PR TITLE
NO-ISSUE: Fix selectors of node network configuration policies

### DIFF
--- a/ztp/internal/data/metallb/objects/0150-nncp.yaml
+++ b/ztp/internal/data/metallb/objects/0150-nncp.yaml
@@ -3,11 +3,11 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: {{ .Name }}-nncp
+  name: {{ .Hostname }}-nncp
 spec:
   parallel: true
   nodeSelector:
-    kubernetes.io/hostname: {{ .Name }}
+    kubernetes.io/hostname: {{ .Hostname }}
   desiredState:
     interfaces:
     - ipv4:


### PR DESCRIPTION
# Description

Currently the node selectors of the node network configuration policies generated for metal load balancers use the name of the node, but they should use the host names instead. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
