### PR TITLE
NO-ISSUE: Add `--color` flag

### DIFF
--- a/ztp/internal/console_flags.go
+++ b/ztp/internal/console_flags.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package internal
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// AddConsoleFlags adds the console flags to the given flag set.
+func AddConsoleFlags(set *pflag.FlagSet) {
+	_ = set.Bool(
+		consoleColorFlag,
+		true,
+		"Enables or disables use of color in the console. By default color is used when "+
+			"the console is a terminal and disabled otherwise.",
+	)
+}
+
+// Names of the flags:
+const (
+	consoleColorFlag = "color"
+)

--- a/ztp/internal/tool.go
+++ b/ztp/internal/tool.go
@@ -202,6 +202,7 @@ func (t *Tool) run(cmd *cobra.Command, args []string) error {
 	// Create the console:
 	t.console, err = NewConsole().
 		SetLogger(t.logger).
+		SetFlags(cmd.Flags()).
 		SetOut(t.out).
 		SetErr(t.err).
 		Build()
@@ -235,6 +236,7 @@ func (t *Tool) createCommand() error {
 	// Add flags that apply to all the commands:
 	flags := t.cmd.PersistentFlags()
 	logging.AddFlags(flags)
+	AddConsoleFlags(flags)
 
 	// Add sub-commands:
 	for _, sub := range t.sub {


### PR DESCRIPTION
# Description

This patch adds a `--color` flag that can be used to explicitly enable/disable use of color in the console.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
