### PR TITLE
NO-ISSUE: Add `create icsp` command

### DIFF
--- a/ztp/internal/cmd/create/create_cmd.go
+++ b/ztp/internal/cmd/create/create_cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	createclustercmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create/cluster"
+	createicspcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create/icsp"
 	createmetallbcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/create/metallb"
 )
 
@@ -29,6 +30,7 @@ func Cobra() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	result.AddCommand(createclustercmd.Cobra())
+	result.AddCommand(createicspcmd.Cobra())
 	result.AddCommand(createmetallbcmd.Cobra())
 	return result
 }

--- a/ztp/internal/cmd/create/icsp/create_icsp_cmd.go
+++ b/ztp/internal/cmd/create/icsp/create_icsp_cmd.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package icsp
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/config"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/jq"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
+)
+
+// Cobra creates and returns the `create icsp` command.
+func Cobra() *cobra.Command {
+	c := NewCommand()
+	result := &cobra.Command{
+		Use:     "icsp",
+		Aliases: []string{"icsps"},
+		Short:   "Creates the image content source policies",
+		Args:    cobra.NoArgs,
+		RunE:    c.Run,
+	}
+	flags := result.Flags()
+	config.AddFlags(flags)
+	return result
+}
+
+// Command contains the data and logic needed to run the `create icsp` command.
+type Command struct {
+	logger  logr.Logger
+	flags   *pflag.FlagSet
+	jq      *jq.Tool
+	console *internal.Console
+	config  *models.Config
+	client  *internal.Client
+}
+
+// Task contains the information necessary to complete each of the tasks that this command runs, in
+// particular it contains the reference to the cluster it works with, so that it isn't necessary to
+// pass this reference around all the time.
+type Task struct {
+	parent  *Command
+	logger  logr.Logger
+	console *internal.Console
+	client  *internal.Client
+	cluster *models.Cluster
+}
+
+// NewCommand creates a new runner that knows how to execute the `create icsp` command.
+func NewCommand() *Command {
+	return &Command{}
+}
+
+// Run runs the `create icsp` command.
+func (c *Command) Run(cmd *cobra.Command, argv []string) error {
+	var err error
+
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the dependencies from the context:
+	c.logger = internal.LoggerFromContext(ctx)
+	c.console = internal.ConsoleFromContext(ctx)
+
+	// Save the flags:
+	c.flags = cmd.Flags()
+
+	// Create the jq tool:
+	c.jq, err = jq.NewTool().
+		SetLogger(c.logger).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create jq tool: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Load the configuration:
+	c.config, err = config.NewLoader().
+		SetLogger(c.logger).
+		SetFlags(c.flags).
+		Load()
+	if err != nil {
+		c.console.Error(
+			"Failed to load configuration: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Create the client for the API:
+	c.client, err = internal.NewClient().
+		SetLogger(c.logger).
+		SetFlags(c.flags).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create client: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Enrich the configuration:
+	enricher, err := internal.NewEnricher().
+		SetLogger(c.logger).
+		SetClient(c.client).
+		SetFlags(c.flags).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create enricher: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+	err = enricher.Enrich(ctx, c.config)
+	if err != nil {
+		c.console.Error(
+			"Failed to enrich configuration: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Create a task for each cluster, and run them:
+	for _, cluster := range c.config.Clusters {
+		task := &Task{
+			parent:  c,
+			logger:  c.logger.WithValues("cluster", cluster.Name),
+			console: c.console,
+			cluster: cluster,
+		}
+		err = task.Run(ctx)
+		if err != nil {
+			c.console.Error(
+				"Failed to create image content source policies for "+
+					"cluster '%s': %v",
+				cluster.Name, err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) Run(ctx context.Context) error {
+	var err error
+
+	// Check that the Kubeconfig is available:
+	if t.cluster.Kubeconfig == nil {
+		return fmt.Errorf(
+			"kubeconfig for cluster '%s' isn't available",
+			t.cluster.Name,
+		)
+	}
+
+	// Check that the SSH key is available:
+	if t.cluster.SSH.PrivateKey == nil {
+		return fmt.Errorf(
+			"SSH key for cluster '%s' isn't available",
+			t.cluster.Name,
+		)
+	}
+
+	// Find the first control plane node that has an external IP:
+	var sshIP *models.IP
+	for _, node := range t.cluster.ControlPlaneNodes() {
+		if node.ExternalIP != nil {
+			sshIP = node.ExternalIP
+			break
+		}
+	}
+	if sshIP == nil {
+		return fmt.Errorf(
+			"failed to find SSH host for cluster '%s' because there is no control "+
+				"plane node that has an external IP address",
+			t.cluster.Name,
+		)
+	}
+
+	// Create the client using a dialer that creates connections tunnelled via the SSH
+	// connection to the cluster:
+	t.client, err = internal.NewClient().
+		SetLogger(t.logger).
+		SetFlags(t.parent.flags).
+		SetKubeconfig(t.cluster.Kubeconfig).
+		SetSSHServer(sshIP.Address.String()).
+		SetSSHUser("core").
+		SetSSHKey(t.cluster.SSH.PrivateKey).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	// Find the URI of the registry of the hub:
+	registry, err := t.getRegistryURI(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get the list of catalogs of the hub:
+	catalogs := &unstructured.UnstructuredList{}
+	catalogs.SetGroupVersionKind(internal.CatalogSourceListGVK)
+	err = t.parent.client.List(ctx, catalogs, clnt.InNamespace("openshift-marketplace"))
+	if err != nil {
+		return err
+	}
+
+	// Create the image content source policies:
+	for _, catalog := range catalogs.Items {
+		err = t.createCatalogICSP(ctx, &catalog, registry)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) getRegistryURI(ctx context.Context) (result string, err error) {
+	config := &corev1.ConfigMap{}
+	key := clnt.ObjectKey{
+		Namespace: "ztpfw-registry",
+		Name:      "ztpfw-config",
+	}
+	err = t.parent.client.Get(ctx, key, config)
+	if err != nil {
+		return
+	}
+	data, ok := config.Data["uri"]
+	if !ok {
+		err = fmt.Errorf(
+			"failed to find registry URI because configmap '%s/%s' doesn't have the "+
+				"'uri' key",
+			config.Namespace, config.Name,
+		)
+		return
+	}
+	value, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return
+	}
+	result = strings.TrimSpace(string(value))
+	return
+}
+
+func (t *Task) createCatalogICSP(ctx context.Context, catalog *unstructured.Unstructured,
+	registry string) error {
+	t.console.Info(
+		"Generating ICSP for catalog '%s' of cluster '%s'",
+		catalog, t.cluster.Name,
+	)
+	icsp, err := t.generateCatalogICSP(ctx, catalog, registry)
+	if err != nil {
+		return err
+	}
+	err = t.client.Create(ctx, icsp)
+	if apierrors.IsAlreadyExists(err) {
+		t.console.Info(
+			"ICSP '%s' for catalog '%s' of cluster '%s' already exists",
+			icsp, catalog, t.cluster.Name,
+		)
+		err = nil
+	}
+	if err != nil {
+		return err
+	}
+	t.console.Info(
+		"Created ICSP '%s' for catalog '%s' of cluster '%s'",
+		icsp, catalog, t.cluster.Name,
+	)
+	return nil
+}
+
+func (t *Task) generateCatalogICSP(ctx context.Context, catalog *unstructured.Unstructured,
+	registry string) (result *unstructured.Unstructured, err error) {
+	t.logger.V(1).Info(
+		"Generating ICSP for catalog source",
+		"catalog", fmt.Sprintf("%s/%s", catalog.GetNamespace(), catalog.GetName()),
+		"registry", registry,
+	)
+	var index string
+	err = t.parent.jq.Query(`.spec.image`, catalog.Object, &index)
+	if err != nil {
+		return
+	}
+	result, err = t.generateIndexICSP(ctx, index, fmt.Sprintf("%s/olm", registry))
+	return
+}
+
+func (t *Task) generateIndexICSP(ctx context.Context,
+	index, target string) (result *unstructured.Unstructured, err error) {
+	// We need to use the `ocm adm catalog mirror` command to generate the image content source
+	// policy. To do so we create a directory, write the pull secret to a file, and then run the
+	// command to generate the result in the same directory.
+	t.logger.V(1).Info(
+		"Generating ICSP for index image",
+		"index", index,
+		"target", target,
+	)
+	tmpDir, err := os.MkdirTemp("", "*.icsp")
+	if err != nil {
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpAuth := filepath.Join(tmpDir, "auth.json")
+	err = os.WriteFile(tmpAuth, t.cluster.PullSecret, 0600)
+	if err != nil {
+		return
+	}
+	ocPath, err := exec.LookPath("oc")
+	if err != nil {
+		return
+	}
+	ocIn := &bytes.Buffer{}
+	ocOut := &bytes.Buffer{}
+	ocErr := &bytes.Buffer{}
+	ocCmd := &exec.Cmd{
+		Path: ocPath,
+		Args: []string{
+			"oc",
+			"adm", "catalog", "mirror",
+			"--insecure",
+			"--registry-config", tmpAuth,
+			"--manifests-only",
+			"--to-manifests", tmpDir,
+			index, target,
+		},
+		Dir:    tmpDir,
+		Env:    append(os.Environ(), "GODEBUG=x509ignoreCN=0"),
+		Stdin:  ocIn,
+		Stdout: ocOut,
+		Stderr: ocErr,
+	}
+	err = ocCmd.Run()
+	t.logger.V(2).Info(
+		"Executed catalog mirror command",
+		"env", ocCmd.Env,
+		"cwd", ocCmd.Dir,
+		"args", ocCmd.Args,
+		"stdout", ocOut.String(),
+		"stderr", ocErr.String(),
+		"code", ocCmd.ProcessState.ExitCode(),
+	)
+	if err != nil {
+		return
+	}
+
+	// Now we parse the generated YAML to generate the object:
+	tmpFile := filepath.Join(tmpDir, "imageContentSourcePolicy.yaml")
+	tmpData, err := os.ReadFile(tmpFile)
+	if err != nil {
+		return
+	}
+	tmpObject := &unstructured.Unstructured{}
+	err = yaml.Unmarshal(tmpData, &tmpObject.Object)
+	if err != nil {
+		return
+	}
+
+	// Return the resulting object:
+	result = tmpObject
+	return
+}

--- a/ztp/internal/data/dev/objects/0050-marketplace-namespace.yaml
+++ b/ztp/internal/data/dev/objects/0050-marketplace-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-marketplace

--- a/ztp/internal/data/dev/objects/0060-catalog-sources.yaml
+++ b/ztp/internal/data/dev/objects/0060-catalog-sources.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  namespace: openshift-marketplace
+  name: certified-operators
+spec:
+  image: registry.redhat.io/redhat/certified-operator-index:v4.11
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  namespace: openshift-marketplace
+  name: redhat-operators
+spec:
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.11
+  sourceType: grpc

--- a/ztp/internal/data/dev/objects/0070-registry-namespace.yaml
+++ b/ztp/internal/data/dev/objects/0070-registry-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ztpfw-registry

--- a/ztp/internal/data/dev/objects/0080-registry-configmap.yaml
+++ b/ztp/internal/data/dev/objects/0080-registry-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: ztpfw-registry
+  name: ztpfw-config
+data:
+  uri: quay.io

--- a/ztp/internal/gvks.go
+++ b/ztp/internal/gvks.go
@@ -40,6 +40,13 @@ var (
 	}
 	BareMetalHostListGVK = listGVK(BareMetalHostGVK)
 
+	CatalogSourceGVK = schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "CatalogSource",
+	}
+	CatalogSourceListGVK = listGVK(CatalogSourceGVK)
+
 	ClusterDeploymentGVK = schema.GroupVersionKind{
 		Group:   "hive.openshift.io",
 		Version: "v1",


### PR DESCRIPTION
# Description

This patch adds a new `create icsp` command that reads the catalog sources and registry configuration from the hub cluster and creates image content source policies in the edge cluster so that images are pulled from the hub registry.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
