### PR TITLE
NO-ISSUE: Trust registry

### DIFF
--- a/ztp/internal/data.go
+++ b/ztp/internal/data.go
@@ -24,6 +24,7 @@ var DataFS embed.FS
 //go:generate -command get curl --silent --location --output
 //go:generate get data/dev/crds/0010_ingresscontroller.yaml   https://raw.githubusercontent.com/openshift/api/release-4.12/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
 //go:generate get data/dev/crds/0011_icsp.yaml                https://raw.githubusercontent.com/openshift/api/release-4.12/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+//go:generate get data/dev/crds/0012_image.yaml               https://raw.githubusercontent.com/openshift/api/release-4.12/config/v1/0000_10_config-operator_01_image.crd.yaml
 //go:generate get data/dev/crds/0015_agent.yaml               https://raw.githubusercontent.com/openshift/assisted-service/v2.14.1/config/crd/bases/agent-install.openshift.io_agents.yaml
 //go:generate get data/dev/crds/0020_agentclusterinstall.yaml https://raw.githubusercontent.com/openshift/assisted-service/v2.14.1/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
 //go:generate get data/dev/crds/0030_clusterdeployment.yaml   https://raw.githubusercontent.com/openshift/hive/master/config/crds/hive.openshift.io_clusterdeployments.yaml

--- a/ztp/internal/data/dev/crds/0012_image.yaml
+++ b/ztp/internal/data/dev/crds/0012_image.yaml
@@ -1,0 +1,108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: images.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Image
+    listKind: ImageList
+    plural: images
+    singular: image
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Image governs policies related to imagestream imports and runtime configuration for external registries. It allows cluster admins to configure which registries OpenShift is allowed to import images from, extra CA trust bundles for external registries, and policies to block or allow registry hostnames. When exposing OpenShift's image registry to the public, this also lets cluster admins specify the external hostname. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                additionalTrustedCA:
+                  description: additionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted during imagestream import, pod image pull, build image pull, and imageregistry pullthrough. The namespace for this config map is openshift-config.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                allowedRegistriesForImport:
+                  description: allowedRegistriesForImport limits the container image registries that normal users may import images from. Set this list to the registries that you trust to contain valid Docker images and that you want applications to be able to import from. Users with permission to create Images or ImageStreamMappings via the API are not affected by this policy - typically only administrators or system integrations will have those permissions.
+                  type: array
+                  items:
+                    description: RegistryLocation contains a location of the registry specified by the registry domain name. The domain name might include wildcards, like '*' or '??'.
+                    type: object
+                    properties:
+                      domainName:
+                        description: domainName specifies a domain name for the registry In case the registry use non-standard (80 or 443) port, the port should be included in the domain name as well.
+                        type: string
+                      insecure:
+                        description: insecure indicates whether the registry is secure (https) or insecure (http) By default (if not specified) the registry is assumed as secure.
+                        type: boolean
+                externalRegistryHostnames:
+                  description: externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in "hostname[:port]" format.
+                  type: array
+                  items:
+                    type: string
+                registrySources:
+                  description: registrySources contains configuration that determines how the container runtime should treat individual registries when accessing images for builds+pods. (e.g. whether or not to allow insecure access).  It does not contain configuration for the internal cluster registry.
+                  type: object
+                  properties:
+                    allowedRegistries:
+                      description: "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied. \n Only one of BlockedRegistries or AllowedRegistries may be set."
+                      type: array
+                      items:
+                        type: string
+                    blockedRegistries:
+                      description: "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted. \n Only one of BlockedRegistries or AllowedRegistries may be set."
+                      type: array
+                      items:
+                        type: string
+                    containerRuntimeSearchRegistries:
+                      description: 'containerRuntimeSearchRegistries are registries that will be searched when pulling images that do not have fully qualified domains in their pull specs. Registries will be searched in the order provided in the list. Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.'
+                      type: array
+                      format: hostname
+                      minItems: 1
+                      items:
+                        type: string
+                      x-kubernetes-list-type: set
+                    insecureRegistries:
+                      description: insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.
+                      type: array
+                      items:
+                        type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                externalRegistryHostnames:
+                  description: externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in "hostname[:port]" format.
+                  type: array
+                  items:
+                    type: string
+                internalRegistryHostname:
+                  description: internalRegistryHostname sets the hostname for the default internal image registry. The value must be in "hostname[:port]" format. This value is set by the image registry operator which controls the internal registry hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/ztp/internal/data/dev/objects/0080-registry-configmap.yaml
+++ b/ztp/internal/data/dev/objects/0080-registry-configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   namespace: ztpfw-registry
   name: ztpfw-config
 data:
-  uri: quay.io
+  uri: cXVheS5pbw==

--- a/ztp/internal/data/dev/objects/image-config.yaml
+++ b/ztp/internal/data/dev/objects/image-config.yaml
@@ -1,0 +1,5 @@
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+spec: {}

--- a/ztp/internal/gvks.go
+++ b/ztp/internal/gvks.go
@@ -61,6 +61,13 @@ var (
 	}
 	CustomResourceDefinitionListGVK = listGVK(CustomResourceDefinitionGVK)
 
+	ImageConfigGVK = schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "Image",
+	}
+	ImageConfigListGVK = listGVK(ImageConfigGVK)
+
 	InfraEnvGKV = schema.GroupVersionKind{
 		Group:   "agent-install.openshift.io",
 		Version: "v1beta1",


### PR DESCRIPTION
# Description

This patch changes the `create icsp` command so that it changes the image pull configuration of the cluster to trust the CA of the registry.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
