### PR TITLE
NO-ISSUE: Use calculated hostname for BMH and BMC secrets

### DIFF
--- a/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
+++ b/ztp/internal/data/cluster/objects/070-nmstateconfig.yaml
@@ -4,7 +4,7 @@ apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig
 metadata:
  namespace: {{ $.Cluster.Name }}
- name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}
+ name: {{ .Hostname }}
  labels:
    nmstate_config_cluster_name: {{ $.Cluster.Name }}
 spec:

--- a/ztp/internal/data/cluster/objects/080-bmc-secret.yaml
+++ b/ztp/internal/data/cluster/objects/080-bmc-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ $.Cluster.Name }}
-  name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}-bmc-secret
+  name: {{ .Hostname }}-bmc-secret
 type: Opaque
 data:
   username: {{ .BMC.User | base64 }}

--- a/ztp/internal/data/cluster/objects/090-baremetalhost.yaml
+++ b/ztp/internal/data/cluster/objects/090-baremetalhost.yaml
@@ -3,7 +3,7 @@
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}
+  name: {{ .Hostname }}
   namespace: {{ $.Cluster.Name }}
   labels:
     infraenvs.agent-install.openshift.io: {{ $.Cluster.Name }}
@@ -19,5 +19,5 @@ spec:
   bmc:
     disableCertificateVerification: true
     address: {{ .BMC.URL }}
-    credentialsName: ztpfw-{{ $.Cluster.Name }}-master-{{ .Index }}-bmc-secret
+    credentialsName: {{ .Hostname }}-bmc-secret
 {{ end}}


### PR DESCRIPTION
# Description

Currently the templates that calculate the names for the bare metal hosts and for the BMC secrets explicitly. This patch changes them so that they use the `Hostname` property of the host instead.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
