### PR TITLE
NO-ISSUE: Add `dev ssh` command

### DIFF
--- a/ztp/internal/cmd/dev/dev_cmd.go
+++ b/ztp/internal/cmd/dev/dev_cmd.go
@@ -21,6 +21,7 @@ import (
 	devcleanupcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/dev/cleanup"
 	devdeletecmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/dev/delete"
 	devsetupcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/dev/setup"
+	devsshcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/dev/ssh"
 )
 
 // Cobra creates and returns the `dev` command.
@@ -36,5 +37,6 @@ func Cobra() *cobra.Command {
 	result.AddCommand(devdeletecmd.Cobra())
 	result.AddCommand(devsetupcmd.Cobra())
 	result.AddCommand(devdeletecmd.Cobra())
+	result.AddCommand(devsshcmd.Cobra())
 	return result
 }

--- a/ztp/internal/cmd/dev/ssh/dev_ssh_cmd.go
+++ b/ztp/internal/cmd/dev/ssh/dev_ssh_cmd.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/config"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
+)
+
+// Cobra creates and returns the `dev ssh` command.
+func Cobra() *cobra.Command {
+	c := NewCommand()
+	result := &cobra.Command{
+		Use:   "ssh",
+		Short: "Connects via SSH to a cluster",
+		Args:  cobra.NoArgs,
+		RunE:  c.run,
+	}
+	flags := result.Flags()
+	config.AddFlags(flags)
+	internal.AddEnricherFlags(flags)
+	_ = flags.String(
+		clusterFlagName,
+		"",
+		"Name of the cluster. This is optional if there is only one cluster "+
+			"in the configuration file.",
+	)
+	_ = flags.String(
+		nodeFlagName,
+		"",
+		"Name of the node. This is optional, the default is to use the first "+
+			"node of the cluster.",
+	)
+	return result
+}
+
+// Command contains the data and logic needed to run the `dev ssh` command.
+type Command struct {
+	logger  logr.Logger
+	flags   *pflag.FlagSet
+	tool    *internal.Tool
+	console *internal.Console
+	client  *internal.Client
+	config  *models.Config
+	cluster *models.Cluster
+	node    *models.Node
+}
+
+// NewCommand creates a new runner that knows how to execute the `dev ssh` command.
+func NewCommand() *Command {
+	return &Command{}
+}
+
+// run executes the `dev ssh` command.
+func (c *Command) run(cmd *cobra.Command, argv []string) (err error) {
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the dependencies from the context:
+	c.logger = internal.LoggerFromContext(ctx)
+	c.tool = internal.ToolFromContext(ctx)
+	c.console = internal.ConsoleFromContext(ctx)
+
+	// Save the flags:
+	c.flags = cmd.Flags()
+
+	// Load the configuration:
+	c.config, err = config.NewLoader().
+		SetLogger(c.logger).
+		SetFlags(c.flags).
+		Load()
+	if err != nil {
+		c.console.Error(
+			"Failed to load configuration: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Try to find matching cluster and node:
+	err = c.selectCluster()
+	if err != nil {
+		c.console.Error("Failed to select cluster: %s", err)
+		return exit.Error(1)
+	}
+	err = c.selectNode()
+	if err != nil {
+		c.console.Error("Failed to select node: %s", err)
+		return exit.Error(1)
+	}
+
+	// Create the client for the API:
+	c.client, err = internal.NewClient().
+		SetLogger(c.logger).
+		SetFlags(c.flags).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create API client: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+	defer c.client.Close()
+
+	// Remove all non selected clusters and nodes from the configuration and enrich the rest.
+	// This will retrieve the SSH key and the IP address of the node.
+	c.console.Info(
+		"Collectiong information for cluster '%s' and node '%s'",
+		c.cluster.Name, c.node.Name,
+	)
+	c.cluster.Nodes = []*models.Node{c.node}
+	c.config.Clusters = []*models.Cluster{c.cluster}
+	enricher, err := internal.NewEnricher().
+		SetLogger(c.logger).
+		SetClient(c.client).
+		SetFlags(c.flags).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create enricher: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+	err = enricher.Enrich(ctx, c.config)
+	if err != nil {
+		c.console.Error(
+			"Failed to enrich configuration: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Run the SSH command:
+	err = c.runSSH()
+	if err != nil {
+		c.console.Error(
+			"Failed to run SSH command: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	return nil
+}
+
+func (c *Command) selectCluster() error {
+	if len(c.config.Clusters) == 0 {
+		return fmt.Errorf("there are not clusters in the configuration")
+	}
+	name, err := c.flags.GetString(clusterFlagName)
+	if err != nil {
+		return fmt.Errorf("failed to get value of flag '--%s': %w", clusterFlagName, err)
+	}
+	if name != "" {
+		c.cluster = c.config.LookupCluster(name)
+		if c.cluster == nil {
+			return fmt.Errorf(
+				"there is no cluster named '%s' in the configuration, try %s",
+				name, logging.Any(c.config.ClusterNames()),
+			)
+		}
+	} else {
+		if len(c.config.Clusters) > 1 {
+			return fmt.Errorf(
+				"there are %d clusters in the configuration, use the '--cluster' "+
+					"option to select %s",
+				len(c.config.Clusters), logging.Any(c.config.ClusterNames()),
+			)
+		}
+		c.cluster = c.config.Clusters[0]
+	}
+	return nil
+}
+
+func (c *Command) selectNode() error {
+	if len(c.cluster.Nodes) == 0 {
+		return fmt.Errorf(
+			"there are not nodes in the configuration for cluster '%s'",
+			c.cluster.Name,
+		)
+	}
+	name, err := c.flags.GetString(nodeFlagName)
+	if err != nil {
+		return fmt.Errorf("failed go get value of flag '--%s': %w", nodeFlagName, err)
+	}
+	if name != "" {
+		c.node = c.cluster.LookupNode(name)
+		if c.node == nil {
+			return fmt.Errorf(
+				"there is no node named '%s' in the configuration for "+
+					"cluster '%s', try %s",
+				name, c.cluster.Name, logging.Any(c.cluster.NodeNames()),
+			)
+		}
+	} else {
+		c.node = c.cluster.Nodes[0]
+	}
+	return nil
+}
+
+func (c *Command) runSSH() error {
+	// Check that the SSH keyBytes is available:
+	keyBytes := c.cluster.SSH.PrivateKey
+	if keyBytes == nil {
+		return fmt.Errorf(
+			"SSH private key for cluster '%s' isn't available",
+			c.cluster.Name,
+		)
+	}
+
+	// Check that the external IP address of the node is available:
+	ip := c.node.ExternalIP
+	if ip == nil {
+		return fmt.Errorf(
+			"IP address for node '%s' isn't available",
+			c.node.Name,
+		)
+	}
+	c.console.Info(
+		"Using IP '%s' to connect to node '%s'",
+		ip.Address, c.node.Name,
+	)
+
+	// Create a temporary directory containing the SSH files:
+	tmpDir, err := os.MkdirTemp("", "*.ssh")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	keyFile := filepath.Join(tmpDir, "key")
+	err = os.WriteFile(keyFile, keyBytes, 0600)
+	if err != nil {
+		return err
+	}
+	hostsFile := filepath.Join(tmpDir, "hosts")
+
+	// Run the SSH command:
+	binary, err := exec.LookPath("ssh")
+	if err != nil {
+		return err
+	}
+	args := []string{
+		"ssh",
+		"-i", keyFile,
+		"-o", "UserKnownHostsFile=" + hostsFile,
+		"-o", "StrictHostKeyChecking=no",
+		"-l", "core",
+		c.node.ExternalIP.Address.String(),
+	}
+	cmd := &exec.Cmd{
+		Path:   binary,
+		Args:   args,
+		Stdin:  c.tool.In(),
+		Stdout: c.tool.Out(),
+		Stderr: c.tool.Err(),
+	}
+	return cmd.Run()
+}
+
+// Names of the command line flags:
+const (
+	clusterFlagName = "cluster"
+	nodeFlagName    = "node"
+)

--- a/ztp/internal/models/cluster.go
+++ b/ztp/internal/models/cluster.go
@@ -53,3 +53,22 @@ func (c *Cluster) WorkerNodes() []*Node {
 	}
 	return nodes
 }
+
+// LookupNode returns an node with the given name, or nil if there is no such node.
+func (c *Cluster) LookupNode(name string) *Node {
+	for _, node := range c.Nodes {
+		if node.Name == name {
+			return node
+		}
+	}
+	return nil
+}
+
+// NodeNames returns a slice containing the names of the nodes.
+func (c *Cluster) NodeNames() []string {
+	names := make([]string, len(c.Nodes))
+	for i, node := range c.Nodes {
+		names[i] = node.Name
+	}
+	return names
+}

--- a/ztp/internal/models/config.go
+++ b/ztp/internal/models/config.go
@@ -18,3 +18,22 @@ type Config struct {
 	Properties map[string]string
 	Clusters   []*Cluster
 }
+
+// LookupCluster returns the cluser with the given name, or nil if no such cluster exists.
+func (c *Config) LookupCluster(name string) *Cluster {
+	for _, cluster := range c.Clusters {
+		if cluster.Name == name {
+			return cluster
+		}
+	}
+	return nil
+}
+
+// ClusterNames returns a slice containing the names of the cluster.
+func (c *Config) ClusterNames() []string {
+	names := make([]string, len(c.Clusters))
+	for i, cluster := range c.Clusters {
+		names[i] = cluster.Name
+	}
+	return names
+}


### PR DESCRIPTION
# Description

Currently development often requires connecting via SSH to the nodes of the clusters. Building the SSH commands required for that is tedious and error prone. To make that simpler this patch adds a development utility that simplfies connecting via SSH to the clusters. If there is only one cluster in the configuration file the following command will find the SSH key of the cluster and the IP address of the first node and connect to it with the `core` user:

```
$ ztp dev ssh -c config.yaml
```

The `--cluster ...` and `--node ...` options allow connecting to specific cluster when there are multiple clusters in the configuration file or to a specific node:

```
$ ztp dev ssh -c config.yaml --cluster my-cluster --node worker0
```

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
