### PR TITLE
MGMT-13116: Use the CLI in the `metallb` step

### DIFF
--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
+    - name: ztp-extra-args
       type: string
-      default: "0"
+      default: ""
   workspaces:
     - name: ztp
   tasks:
@@ -56,8 +56,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - pre-flight
     workspaces:
@@ -71,14 +71,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
-      - name: kubeconfig
-        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -93,14 +93,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
-      - name: kubeconfig
-        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
+    - name: ztp-extra-args
       type: string
-      default: "0"
+      default: ""
   workspaces:
     - name: ztp
   tasks:
@@ -56,8 +56,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - pre-flight
     workspaces:
@@ -79,6 +79,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -93,20 +95,19 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
-      - name: kubeconfig
-        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:
       - name: ztp
         workspace: ztp
-
 
   # Deploy LVMO
   - name: deploy-lvmo

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
+    - name: ztp-extra-args
       type: string
-      default: "0"
+      default: ""
   workspaces:
     - name: ztp
   tasks:
@@ -57,8 +57,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - pre-flight
     workspaces:
@@ -80,6 +80,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -94,20 +96,19 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
-      - name: kubeconfig
-        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:
       - name: ztp
         workspace: ztp
-
 
   # Deploy LVMO
   - name: deploy-lvmo

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
+    - name: ztp-extra-args
       type: string
-      default: "0"
+      default: ""
   workspaces:
     - name: ztp
   tasks:
@@ -57,8 +57,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - pre-flight
     workspaces:
@@ -80,6 +80,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -94,14 +96,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
-      - name: kubeconfig
-        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
+      - name: ztp-extra-args
+        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
@@ -21,9 +21,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
+    - name: ztp-extra-args
       type: string
-      default: "0"
+      default: ""
   stepTemplate:
     env:
       - name: MOCK
@@ -39,10 +39,10 @@ spec:
           ztp create clusters \
           --config "$(params.edgeclusters-config)" \
           --output "/workspace/ztp/$(params.pipeline-name)" \
-          --mute \
-          --log-file "stdout" \
-          --log-level "$(params.ztp-log-level)" \
-          --wait "2h30m"
+          --wait "2h30m" \
+          --log-field "pr=$(params.pipeline-name)" \
+          --log-field "tr=$(context.taskRun.name)" \
+          $(params.ztp-extra-args)
         else
           echo "Deploy Edge-cluster: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
@@ -12,9 +12,6 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
-    - name: kubeconfig
-      type: string
-      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -24,22 +21,11 @@ spec:
     - name: mock
       type: string
       default: "false"
+    - name: ztp-extra-args
+      type: string
+      default: ""
   stepTemplate:
     env:
-      - name: WORKDIR
-        value: "/workspace/ztp/$(params.pipeline-name)"
-      - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
-      - name: EDGECLUSTERS_CONFIG
-        value: $(params.edgeclusters-config)
-      - name: KUBECONFIG
-        value: "$(workspaces.ztp.path)/kubeconfig"
-      - name: DEPLOY_EDGECLUSTERS_DIR
-        value: "deploy-edgecluster"
-      - name: DEPLOY_REGISTRY_DIR
-        value: "deploy-disconnected-registry"
-      - name: SHARED_DIR
-        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
@@ -50,8 +36,11 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          cd ${WORKDIR}/${DEPLOY_EDGECLUSTERS_DIR}
-          ./configure_disconnected.sh 'edgecluster' 'pre'
+          ztp create icsps \
+          --config "$(params.edgeclusters-config)" \
+          --log-field "pr=$(params.pipeline-name)" \
+          --log-field "tr=$(context.taskRun.name)" \
+          $(params.ztp-extra-args)
         else
           echo "Deploy ICSP Pre: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
@@ -12,9 +12,6 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
-    - name: kubeconfig
-      type: string
-      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -24,22 +21,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-  stepTemplate:
-    env:
-      - name: WORKDIR
-        value: "/workspace/ztp/$(params.pipeline-name)"
-      - name: OUTPUTDIR
-        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
-      - name: EDGECLUSTERS_CONFIG
-        value: $(params.edgeclusters-config)
-      - name: KUBECONFIG
-        value: "$(workspaces.ztp.path)/kubeconfig"
-      - name: DEPLOY_METALLB_DIR
-        value: "deploy-metallb"
-      - name: SHARED_DIR
-        value: "shared-utils"
-      - name: MOCK
-        value: $(params.mock)
+    - name: ztp-extra-args
+      type: string
+      default: ""
   steps:
     - name: deploy-metallb
       image: "$(params.ztp-container-image)"
@@ -47,9 +31,13 @@ spec:
       script: |
         #!/usr/bin/bash
 
-        if [[ "${MOCK}" == 'false' ]]; then
-          cd ${WORKDIR}/${DEPLOY_METALLB_DIR}
-          ./deploy.sh
+        if [[ "$(params.mock)" == 'false' ]]; then
+          ztp create metallbs \
+          --config "$(params.edgeclusters-config)" \
+          --log-field "$(params.pipeline-name)" \
+          --log-field "$(context.taskRun.name)" \
+          --wait "30m" \
+          $(params.ztp-extra-args)
         else
           echo "Deploy MetalLB: Mock mode on"
         fi


### PR DESCRIPTION
# Description

This patch changes the pipelines to use the `ztp` CLI in the `metallb` steps instead of the shell scripts.

Related: https://issues.redhat.com/browse/MGMT-13116

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
