### PR TITLE
NO-ISSUE: Remove duplicated `ztp-log-level` parameter

### DIFF
--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -18,9 +18,6 @@ spec:
     - name: ztp-log-level
       type: string
       default: "0"
-    - name: ztp-log-level
-      type: string
-      default: "0"
   workspaces:
     - name: ztp
   tasks:


### PR DESCRIPTION
# Description

The patch that introduced the `ztp-log-level` parameter duplicated it in the `deploy-ztp-egeclusters` pipeline. This patch fixes that.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
