### PR TITLE
NO-ISSUE: Redact security sensitive log fields

### DIFF
--- a/ztp/internal/logging/flags.go
+++ b/ztp/internal/logging/flags.go
@@ -62,6 +62,11 @@ func AddFlags(set *pflag.FlagSet) {
 		"Include details of HTTP request and response bodies in log messages. Note "+
 			"that currently only the size is written, not the complete body.",
 	)
+	_ = set.Bool(
+		redactFlagName,
+		true,
+		"Enables or disables redactiong security sensitive data from the log.",
+	)
 }
 
 // Names of the flags:
@@ -72,4 +77,5 @@ const (
 	fieldsFlagName  = "log-fields"
 	headersFlagName = "log-headers"
 	bodiesFlagName  = "log-bodies"
+	redactFlagName  = "log-redact"
 )

--- a/ztp/internal/logging/sink.go
+++ b/ztp/internal/logging/sink.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package logging
+
+import (
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+// sink is an implementation of the logr.LogSink interface that processes the fields of log messages
+// before sending them to the underlying logger. For example, it redacts the values of security
+// sensitive fields.
+type sink struct {
+	settings *sinkSettings
+	delegate logr.LogSink
+}
+
+// sinkSettings stores settings shared by multiple sinks.
+type sinkSettings struct {
+	redact bool
+}
+
+// Make sure we implement the logr.LogSink interface.
+var _ logr.LogSink = (*sink)(nil)
+
+func (s *sink) Enabled(level int) bool {
+	return s.delegate.Enabled(level)
+}
+
+func (s *sink) Error(err error, msg string, fields ...any) {
+	s.processFields(fields)
+	s.delegate.Error(err, msg, fields...)
+}
+
+func (s *sink) Info(level int, msg string, fields ...any) {
+	s.processFields(fields)
+	s.delegate.Info(level, msg, fields...)
+}
+
+func (s *sink) Init(info logr.RuntimeInfo) {
+	s.delegate.Init(info)
+}
+
+func (s *sink) WithName(name string) logr.LogSink {
+	return &sink{
+		settings: s.settings,
+		delegate: s.delegate.WithName(name),
+	}
+}
+
+func (s *sink) WithValues(fields ...any) logr.LogSink {
+	s.processFields(fields)
+	return &sink{
+		settings: s.settings,
+		delegate: s.delegate.WithValues(fields...),
+	}
+}
+
+func (s *sink) processFields(args []any) {
+	for i := 0; i < len(args); i += 2 {
+		name, ok := args[i].(string)
+		if ok {
+			if strings.HasPrefix(name, "!") {
+				args[i] = name[1:]
+				if s.settings.redact {
+					args[i+1] = "***"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Description

This patch adds the capability to redact security sensitive fields from the logs. Those fields will be marked with an exclamation mark prefix, and will be redacted by default. For example:

```go
logger.Info(
	"SSH keys",
	"public", publicKey,
	"!private", privateKey,
)
```

Will generate a log message like this:

```json
{
	"msg": "SSH keys",
	"public": "ssh-rsa AAA...",
	"private": "***"
}
```

Redacting can be enabled with the new `--log-redact=[true|false]` command line option.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
