### PR TITLE
NO-ISSUE: Delete CRDs when deleting metal load balancer

### DIFF
--- a/ztp/internal/cmd/create/metallb/create_metallb_cmd.go
+++ b/ztp/internal/cmd/create/metallb/create_metallb_cmd.go
@@ -16,6 +16,7 @@ package metallb
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -49,6 +50,18 @@ type Command struct {
 	flags   *pflag.FlagSet
 	console *internal.Console
 	config  *models.Config
+	client  *internal.Client
+}
+
+// Task contains the information necessary to complete each of the tasks that this command runs, in
+// particular it contains the reference to the cluster it works with, so that it isn't necessary to
+// pass this reference around all the time.
+type Task struct {
+	parent  *Command
+	logger  logr.Logger
+	flags   *pflag.FlagSet
+	console *internal.Console
+	cluster *models.Cluster
 	client  *internal.Client
 }
 
@@ -119,105 +132,98 @@ func (c *Command) Run(cmd *cobra.Command, argv []string) error {
 		return exit.Error(1)
 	}
 
-	// Create the load balancers:
+	// Create a task for each cluster, and run them:
 	for _, cluster := range c.config.Clusters {
-		err = c.createLB(ctx, cluster)
+		task := &Task{
+			parent:  c,
+			logger:  c.logger.WithValues("cluster", cluster.Name),
+			flags:   c.flags,
+			console: c.console,
+			cluster: cluster,
+		}
+		err = task.Run(ctx)
 		if err != nil {
 			c.console.Error(
 				"Failed to create load balancer for cluster '%s': %v",
 				cluster.Name, err,
 			)
-			return exit.Error(1)
 		}
 	}
 
 	return nil
 }
 
-func (c *Command) createLB(ctx context.Context, cluster *models.Cluster) error {
+func (t *Task) Run(ctx context.Context) error {
+	var err error
+
 	// Check that the Kubeconfig is available:
-	if cluster.Kubeconfig == nil {
-		c.console.Error(
-			"Kubeconfig for cluster '%s' isn't available",
-			cluster.Name,
+	if t.cluster.Kubeconfig == nil {
+		return fmt.Errorf(
+			"kubeconfig for cluster '%s' isn't available",
+			t.cluster.Name,
 		)
-		return exit.Error(1)
 	}
 
 	// Check that the SSH key is available:
-	if cluster.SSH.PrivateKey == nil {
-		c.console.Error(
+	if t.cluster.SSH.PrivateKey == nil {
+		return fmt.Errorf(
 			"SSH key for cluster '%s' isn't available",
-			cluster.Name,
+			t.cluster.Name,
 		)
-		return exit.Error(1)
 	}
 
 	// Find the first control plane node that has an external IP:
 	var sshIP *models.IP
-	for _, node := range cluster.ControlPlaneNodes() {
+	for _, node := range t.cluster.ControlPlaneNodes() {
 		if node.ExternalIP != nil {
 			sshIP = node.ExternalIP
 			break
 		}
 	}
 	if sshIP == nil {
-		c.console.Error(
-			"Failed to find SSH host for cluster '%s' because there is no control "+
+		return fmt.Errorf(
+			"failed to find SSH host for cluster '%s' because there is no control "+
 				"plane node that has an external IP address",
-			cluster.Name,
+			t.cluster.Name,
 		)
-		return exit.Error(1)
 	}
 
 	// Create the client using a dialer that creates connections tunnelled via the SSH
 	// connection to the cluster:
-	client, err := internal.NewClient().
-		SetLogger(c.logger).
-		SetFlags(c.flags).
-		SetKubeconfig(cluster.Kubeconfig).
+	t.client, err = internal.NewClient().
+		SetLogger(t.logger).
+		SetFlags(t.flags).
+		SetKubeconfig(t.cluster.Kubeconfig).
 		SetSSHServer(sshIP.Address.String()).
 		SetSSHUser("core").
-		SetSSHKey(cluster.SSH.PrivateKey).
+		SetSSHKey(t.cluster.SSH.PrivateKey).
 		Build()
 	if err != nil {
-		c.console.Error(
-			"Failed to create API client: %v",
-			err,
-		)
-		return exit.Error(1)
+		return err
 	}
 
 	// Create the applier:
 	listener, err := internal.NewApplierListener().
-		SetLogger(c.logger).
-		SetConsole(c.console).
+		SetLogger(t.logger).
+		SetConsole(t.console).
 		Build()
 	if err != nil {
-		c.console.Error(
-			"Failed to create listener: %v",
-			err,
-		)
-		return exit.Error(1)
+		return err
 	}
 	applier, err := internal.NewApplier().
-		SetLogger(c.logger).
+		SetLogger(t.logger).
 		SetListener(listener.Func).
-		SetClient(client).
+		SetClient(t.client).
 		SetFS(internal.DataFS).
 		SetRoot("data/metallb").
 		SetDir("objects").
 		Build()
 	if err != nil {
-		c.console.Error(
-			"Failed to create applier: %v",
-			err,
-		)
-		return exit.Error(1)
+		return err
 	}
 
 	// Create the objects:
 	return applier.Apply(ctx, map[string]any{
-		"Cluster": cluster,
+		"Cluster": t.cluster,
 	})
 }


### PR DESCRIPTION
# Description

This patch changes the `ztp delete metallb` so that it also deletes the CRDs in the groups `metalb.io` and `nmstate.io` groups if the `--crds=true` option is used. This is intended for use in development environments where it is convenient to completely delete them to be able to fully test the `ztp create metallb` command.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
