### PR TITLE
NO-ISSUE: Add `delete lso` command

### DIFF
--- a/ztp/internal/cmd/delete/delete_cmd.go
+++ b/ztp/internal/cmd/delete/delete_cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	deleteclustercmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/delete/cluster"
+	deletelsocmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/delete/lso"
 	deletemetallbcmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/delete/metallb"
 	deleteuicmd "github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/cmd/delete/ui"
 )
@@ -30,6 +31,7 @@ func Cobra() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	result.AddCommand(deleteclustercmd.Cobra())
+	result.AddCommand(deletelsocmd.Cobra())
 	result.AddCommand(deletemetallbcmd.Cobra())
 	result.AddCommand(deleteuicmd.Cobra())
 	return result

--- a/ztp/internal/cmd/delete/lso/delete_lso_cmd.go
+++ b/ztp/internal/cmd/delete/lso/delete_lso_cmd.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package lso
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/config"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/exit"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/models"
+)
+
+// Cobra creates and returns the `create lso` command.
+func Cobra() *cobra.Command {
+	c := NewCommand()
+	result := &cobra.Command{
+		Use:     "lso",
+		Aliases: []string{"lsos"},
+		Short:   "Deletes local storage operator",
+		Args:    cobra.NoArgs,
+		RunE:    c.Run,
+	}
+	flags := result.Flags()
+	config.AddFlags(flags)
+	internal.AddEnricherFlags(flags)
+	_ = flags.Bool(
+		crdsFlagName,
+		false,
+		"Enabled or disables deletion of the custom resource definitions of the "+
+			"'local.storage.openshift.io' group that are created when the local "+
+			"storage operator is created. This is itended for use in testing and "+
+			"developments environments and shouldn't be used in production "+
+			"environments.",
+	)
+	return result
+}
+
+// Command contains the data and logic needed to run the `create lso` command.
+type Command struct {
+	logger  logr.Logger
+	flags   *pflag.FlagSet
+	console *internal.Console
+	config  *models.Config
+	client  *internal.Client
+}
+
+// Task contains the information necessary to complete each of the tasks that this command runs, in
+// particular it contains the reference to the cluster it works with, so that it isn't necessary to
+// pass this reference around all the time.
+type Task struct {
+	parent  *Command
+	logger  logr.Logger
+	flags   *pflag.FlagSet
+	console *internal.Console
+	cluster *models.Cluster
+	client  *internal.Client
+}
+
+// NewCommand creates a new runner that knows how to execute the `create lso` command.
+func NewCommand() *Command {
+	return &Command{}
+}
+
+// Run runs the `create lso` command.
+func (c *Command) Run(cmd *cobra.Command, argv []string) error {
+	var err error
+
+	// Get the context:
+	ctx := cmd.Context()
+
+	// Get the dependencies from the context:
+	c.logger = internal.LoggerFromContext(ctx)
+	c.console = internal.ConsoleFromContext(ctx)
+
+	// Save the flags:
+	c.flags = cmd.Flags()
+
+	// Load the configuration:
+	c.config, err = config.NewLoader().
+		SetLogger(c.logger).
+		SetFlags(c.flags).
+		Load()
+	if err != nil {
+		c.console.Error(
+			"Failed to load configuration: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Create the client for the API:
+	c.client, err = internal.NewClient().
+		SetLogger(c.logger).
+		SetFlags(c.flags).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create API client: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Enrich the configuration:
+	enricher, err := internal.NewEnricher().
+		SetLogger(c.logger).
+		SetClient(c.client).
+		SetFlags(c.flags).
+		Build()
+	if err != nil {
+		c.console.Error(
+			"Failed to create enricher: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+	err = enricher.Enrich(ctx, c.config)
+	if err != nil {
+		c.console.Error(
+			"Failed to enrich configuration: %v",
+			err,
+		)
+		return exit.Error(1)
+	}
+
+	// Create a task for each cluster, and run them:
+	for _, cluster := range c.config.Clusters {
+		task := &Task{
+			parent:  c,
+			logger:  c.logger.WithValues("cluster", cluster.Name),
+			flags:   c.flags,
+			console: c.console,
+			cluster: cluster,
+		}
+		err = task.Run(ctx)
+		if err != nil {
+			c.console.Error(
+				"Failed to delete local storage operator for cluster '%s': %v",
+				cluster.Name, err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) Run(ctx context.Context) error {
+	var err error
+
+	// Check that the Kubeconfig is available:
+	if t.cluster.Kubeconfig == nil {
+		return errors.New("kubeconfig isn't available")
+	}
+
+	// Create the client to connect to the cluster:
+	t.client, err = internal.NewClient().
+		SetLogger(t.logger).
+		SetFlags(t.flags).
+		SetKubeconfig(t.cluster.Kubeconfig).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	// Delete the operator:
+	err = t.deleteLSO(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Task) deleteLSO(ctx context.Context) error {
+	// Create the applier:
+	listener, err := internal.NewApplierListener().
+		SetLogger(t.logger).
+		SetConsole(t.console).
+		Build()
+	if err != nil {
+		return err
+	}
+	applier, err := internal.NewApplier().
+		SetLogger(t.logger).
+		SetListener(listener.Func).
+		SetClient(t.client).
+		SetFS(internal.DataFS).
+		SetRoot("data/lso/objects").
+		Build()
+	if err != nil {
+		return err
+	}
+
+	// Delete the objects:
+	err = applier.Delete(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	// Deleting the CRDs:
+	crds, err := t.flags.GetBool(crdsFlagName)
+	if err != nil {
+		return err
+	}
+	if crds {
+		t.console.Warn("CRDs in group 'local.storage.openshift.io' will be deleted")
+		err = t.deleteCRDGroup(ctx, "local.storage.openshift.io")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) deleteCRDGroup(ctx context.Context, group string) error {
+	n, err := t.client.DeleteCRDGroup(ctx, group)
+	if err != nil {
+		return err
+	}
+	switch {
+	case n == 0:
+		t.console.Info(
+			"There are CRDs to delete in group '%s' in cluster '%s'",
+			group, t.cluster.Name,
+		)
+	case n == 1:
+		t.console.Info(
+			"Deleted one CRD in group '%s' in cluster '%s'",
+			group, t.cluster.Name,
+		)
+	default:
+		t.console.Info(
+			"Deleted %d CRDs in group '%s' in cluster '%s",
+			n, group, t.cluster.Name,
+		)
+	}
+	return nil
+}
+
+// Names of command line flags:
+const (
+	crdsFlagName = "crds"
+)

--- a/ztp/internal/data/lso/objects/0020-operatorgroup.yaml
+++ b/ztp/internal/data/lso/objects/0020-operatorgroup.yaml
@@ -1,8 +1,8 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: local-storage-operator-operatorgroup
   namespace: openshift-local-storage
+  name: local-storage-operator-operatorgroup
 spec:
   targetNamespaces:
   - openshift-local-storage

--- a/ztp/internal/data/lso/objects/0030-subscription.yaml
+++ b/ztp/internal/data/lso/objects/0030-subscription.yaml
@@ -1,10 +1,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: local-storage-operator
   namespace: openshift-local-storage
+  name: local-storage-operator
 spec:
-  channel: "stable"
+  channel: stable
   name: local-storage-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/ztp/internal/data/lso/objects/0040-localvolume.yaml
+++ b/ztp/internal/data/lso/objects/0040-localvolume.yaml
@@ -11,15 +11,17 @@ spec:
     - matchExpressions:
       - key: kubernetes.io/hostname
         operator: In
-        values:
-        {{ range .Hostnames }}
-        - {{ . }}
-        {{ end }}
+        values: [
+          {{ range .Hostnames -}}
+          {{ . }},
+          {{ end -}}
+        ]
   storageClassDevices:
-  - devicePaths:
-    {{ range .Disks }}
-    - {{ . }}
-    {{ end }}
+  - devicePaths: [
+      {{ range .Disks -}}
+      {{ . }},
+      {{ end -}}
+    ]
     fsType: xfs
     storageClassName: localstorage-sc-block
     volumeMode: Block


### PR DESCRIPTION
# Description

This patch adds a new `ztp delete lso` command that deletes the objects created by the `ztp create lso` command. This is intended for use in development environments, where it is convenient ro un the create command multiple times without having to manually delete the objects or else create the cluster from scratch.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
