### PR TITLE
NO-ISSUE: Supress noise HTTP logs

### DIFF
--- a/ztp/internal/client.go
+++ b/ztp/internal/client.go
@@ -258,6 +258,8 @@ func (b *ClientBuilder) loadConfig() (result *rest.Config, err error) {
 		loggingWrapper, err = logging.NewTransportWrapper().
 			SetLogger(b.logger).
 			SetFlags(b.flags).
+			AddExclude("^/api(/v1)?$").
+			AddExclude("^/apis(/.*)?$").
 			Build()
 		if err != nil {
 			return


### PR DESCRIPTION
# Description

The Kubernetes API client sends multiple initial requestst to retrieve metadata. These don't provide any useful information and pollute the log. This patch changes the logger so that it discards these requests.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
