### PR TITLE
NO-ISSUE: Fix `create lso` command

### DIFF
--- a/ztp/internal/cmd/lso/create_lso_cmd.go
+++ b/ztp/internal/cmd/lso/create_lso_cmd.go
@@ -40,13 +40,13 @@ import (
 
 // Create creates and returns the `create lso` command.
 func Create() *cobra.Command {
-	c := NewDeleteCommand()
+	c := NewCreateCommand()
 	result := &cobra.Command{
 		Use:     "lso",
 		Aliases: []string{"lsos"},
 		Short:   "Deploys local storage operator",
 		Args:    cobra.NoArgs,
-		RunE:    c.Run,
+		RunE:    c.run,
 	}
 	flags := result.Flags()
 	config.AddFlags(flags)
@@ -90,8 +90,8 @@ func NewCreateCommand() *CreateCommand {
 	return &CreateCommand{}
 }
 
-// Run runs the `create lso` command.
-func (c *CreateCommand) Run(cmd *cobra.Command, argv []string) error {
+// run runs the `create lso` command.
+func (c *CreateCommand) run(cmd *cobra.Command, argv []string) error {
 	var err error
 
 	// Get the context:
@@ -174,7 +174,7 @@ func (c *CreateCommand) Run(cmd *cobra.Command, argv []string) error {
 			console: c.console,
 			cluster: cluster,
 		}
-		err = task.Run(ctx)
+		err = task.run(ctx)
 		if err != nil {
 			c.console.Error(
 				"Failed to create local storage operator for cluster '%s': %v",
@@ -186,7 +186,7 @@ func (c *CreateCommand) Run(cmd *cobra.Command, argv []string) error {
 	return nil
 }
 
-func (t *CreateTask) Run(ctx context.Context) error {
+func (t *CreateTask) run(ctx context.Context) error {
 	var err error
 
 	// Check that the Kubeconfig is available:
@@ -325,7 +325,7 @@ func (t *CreateTask) wipeDisks(ctx context.Context, node *models.Node) error {
 	engine, err := templating.NewEngine().
 		SetLogger(t.logger).
 		SetFS(templatesFS).
-		SetDir("templates/lso/scripts").
+		SetDir("templates/scripts").
 		Build()
 	if err != nil {
 		return err
@@ -376,7 +376,7 @@ func (t *CreateTask) deployLSO(ctx context.Context) error {
 		SetListener(listener.Func).
 		SetClient(t.client).
 		SetFS(templatesFS).
-		SetRoot("templates/lso/objects").
+		SetRoot("templates/objects").
 		Build()
 	if err != nil {
 		return err

--- a/ztp/internal/cmd/lso/delete_lso_cmd.go
+++ b/ztp/internal/cmd/lso/delete_lso_cmd.go
@@ -36,7 +36,7 @@ func Delete() *cobra.Command {
 		Aliases: []string{"lsos"},
 		Short:   "Deletes local storage operator",
 		Args:    cobra.NoArgs,
-		RunE:    c.Run,
+		RunE:    c.run,
 	}
 	flags := result.Flags()
 	config.AddFlags(flags)
@@ -79,8 +79,8 @@ func NewDeleteCommand() *DeleteCommand {
 	return &DeleteCommand{}
 }
 
-// Run runs the `delete lso` command.
-func (c *DeleteCommand) Run(cmd *cobra.Command, argv []string) error {
+// run runs the `delete lso` command.
+func (c *DeleteCommand) run(cmd *cobra.Command, argv []string) error {
 	var err error
 
 	// Get the context:
@@ -150,7 +150,7 @@ func (c *DeleteCommand) Run(cmd *cobra.Command, argv []string) error {
 			console: c.console,
 			cluster: cluster,
 		}
-		err = task.Run(ctx)
+		err = task.run(ctx)
 		if err != nil {
 			c.console.Error(
 				"Failed to delete local storage operator for cluster '%s': %v",
@@ -162,7 +162,7 @@ func (c *DeleteCommand) Run(cmd *cobra.Command, argv []string) error {
 	return nil
 }
 
-func (t *DeleteTask) Run(ctx context.Context) error {
+func (t *DeleteTask) run(ctx context.Context) error {
 	var err error
 
 	// Check that the Kubeconfig is available:
@@ -203,7 +203,8 @@ func (t *DeleteTask) deleteLSO(ctx context.Context) error {
 		SetListener(listener.Func).
 		SetClient(t.client).
 		SetFS(templatesFS).
-		SetRoot("templates/objects").
+		SetRoot("templates").
+		SetDir("objects").
 		Build()
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

When the `create lso` and `delete lso` commands were moved to the same packaged an error was introduced that makes the `create lso` command execute the logic of the `delete lso` command. This patch fixes that issue.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
