### PR TITLE
MGMT-13924: Restart watches when API server is restarted

### DIFF
--- a/ztp/internal/logging/sink.go
+++ b/ztp/internal/logging/sink.go
@@ -15,9 +15,11 @@ License.
 package logging
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // sink is an implementation of the logr.LogSink interface that processes the fields of log messages
@@ -80,5 +82,23 @@ func (s *sink) processFields(args []any) {
 				}
 			}
 		}
+		value := args[i+1]
+		switch value.(type) {
+		case *metav1.Status:
+			args[i+1] = s.pretty(value)
+		}
 	}
+}
+
+func (s *sink) pretty(object any) any {
+	data, err := json.Marshal(object)
+	if err != nil {
+		return object
+	}
+	var result any
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		return object
+	}
+	return result
 }


### PR DESCRIPTION
# Description

When the API server is restarted the existing watches are closed, and trying to start them again may result in requesting a resource version that is too old and has alreayd been forgotten/compacted by etcd. That results in receiving an `ERROR` event with code `420 Gone` indicating that the resource version is too old. In that situation the CLI currently just tries to create the watch again, but using the same resource version. That results into an infinite loop. This patch fixes that issue. When the CLI receives the `ERROR` event it will restart the watch from version `0`.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
