### PR TITLE
NO-ISSUE: Ignore bookmark events

### DIFF
--- a/ztp/internal/applier.go
+++ b/ztp/internal/applier.go
@@ -479,6 +479,9 @@ func (a *Applier) waitCRDs(ctx context.Context, gvks ...schema.GroupVersionKind)
 	}
 	defer watch.Stop()
 	for event := range watch.ResultChan() {
+		if event.Type == apiwatch.Bookmark {
+			continue
+		}
 		crd, ok := event.Object.(*unstructured.Unstructured)
 		if !ok {
 			continue

--- a/ztp/internal/cmd/cluster/create_cluster_cmd.go
+++ b/ztp/internal/cmd/cluster/create_cluster_cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal"
@@ -298,6 +299,9 @@ func (c *CreateCommand) waitHosts(ctx context.Context, cluster *models.Cluster) 
 	}
 	defer watch.Stop()
 	for event := range watch.ResultChan() {
+		if event.Type == apiwatch.Bookmark {
+			continue
+		}
 		object, ok := event.Object.(*unstructured.Unstructured)
 		if !ok {
 			continue
@@ -348,6 +352,9 @@ func (c *CreateCommand) waitInstall(ctx context.Context, cluster *models.Cluster
 	defer watch.Stop()
 	previousState := ""
 	for event := range watch.ResultChan() {
+		if event.Type == apiwatch.Bookmark {
+			continue
+		}
 		object, ok := event.Object.(*unstructured.Unstructured)
 		if !ok {
 			continue


### PR DESCRIPTION
# Description

The watches that we create to wait for cluster installation to be completed don't need to process the bookmark events because they are already processed by the unerlying watch. Processing them produces incorrect results because those events don't contain any event data, only the resource version. This patch changes those watches so that they ingore bookmark events.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
