### PR TITLE
MGMT-13974: Remove `--wipe` option of `create lso`

### DIFF
--- a/ztp/internal/annotations/annotations.go
+++ b/ztp/internal/annotations/annotations.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package annotations
+
+// This file contains constants for frequently used annotations.
+
+// Wiped is the annotation that we use to mark namespaces after the disks of the cluster have been
+// wiped.
+const Wiped = prefix + "/wiped"
+
+// prefix is the prefix for all the annotations.
+const prefix = "ztpfw"


### PR DESCRIPTION
# Description

This patch removes the `--wipe` option of the `create lso` command. Instead of requiring that option the command will write a `ztpfw/wiped: true|false` annotation in the namespace of the cluster. If the annotation exists it will not do the wiping. If the annotation doesn't exist it will do the wiping and add the annotation. This makes the command idempotent.

Related: https://issues.redhat.com/browse/MGMT-13974

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
