### PR TITLE
NO-ISSUE: Fix use of deprecated MetalLB CRDs in UI

### DIFF
--- a/ui/frontend/src/components/PersistPage/persistServices.ts
+++ b/ui/frontend/src/components/PersistPage/persistServices.ts
@@ -31,7 +31,7 @@ const createAddressPool = async (
     const object = cloneDeep(ADDRESS_POOL_TEMPLATE);
     object.metadata.generateName = `ztpfw-${type}-`;
     // object.metadata.namespace = namespace;
-    object.spec.addresses = [`${serviceIp}-${serviceIp}`];
+    object.spec.addresses = [`${serviceIp}/32`];
 
     const response = await createResource(object).promise;
     console.log('Resource created: ', response);
@@ -65,20 +65,20 @@ const patchAddressPool = async (
     {
       op: 'replace',
       path: '/spec/addresses',
-      value: [`${serviceIp}-${serviceIp}`],
+      value: [`${serviceIp}/32`],
     },
   ];
 
   try {
     await patchResource(addrPoolObj, addrPoolPatches).promise;
     console.log(
-      `Patched ${addressPoolName} AddressPool name in the ${ADDRESS_POOL_NAMESPACE} namespace`,
+      `Patched ${addressPoolName} IPAddressPool name in the ${ADDRESS_POOL_NAMESPACE} namespace`,
     );
   } catch (e) {
     console.error('Can not patch resource: ', e, addrPoolObj, addrPoolPatches);
     setError({
       title: RESOURCE_PATCH_TITLE,
-      message: `Can not update ${addressPoolName} AddressPool in the ${ADDRESS_POOL_NAMESPACE} namespace.`,
+      message: `Can not update ${addressPoolName} IPAddressPool in the ${ADDRESS_POOL_NAMESPACE} namespace.`,
     });
     return false;
   }

--- a/ui/frontend/src/components/PersistPage/resourceTemplates.ts
+++ b/ui/frontend/src/components/PersistPage/resourceTemplates.ts
@@ -9,17 +9,17 @@ import {
 import { ADDRESS_POOL_NAMESPACE } from './constants';
 
 export const ADDRESS_POOL_TEMPLATE = {
-  apiVersion: 'metallb.io/v1alpha1',
-  kind: 'AddressPool',
+  apiVersion: 'metallb.io/v1beta1',
+  kind: 'IPAddressPool',
   metadata: {
     generateName: 'ztpfw-', // To be filled
     name: '',
     namespace: ADDRESS_POOL_NAMESPACE,
   },
   spec: {
-    protocol: 'layer2',
+    autoAssign: false,
     addresses: [
-      '', // To be filled, example: '172.18.0.100-172.18.0.255',
+      '', // To be filled, example: '172.18.0.100/32',
     ],
   },
 };


### PR DESCRIPTION
# Description

Currently the UI tries to create/modify the deprecated `AdressPool` object, but that object is no longer used in the current MetalLB configuration because it has been replaced by `IPAddressPool`. This patch adjusts the UI accordingly.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
