### PR TITLE
NO-ISSUE: Add registry tool

### DIFF
--- a/ztp/internal/registry_tool.go
+++ b/ztp/internal/registry_tool.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package internal
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/go-logr/logr"
+	"github.com/imdario/mergo"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/jq"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RegistryToolBuilder contains the data and logic needed to create an instance of the registry
+// tool.  Don't create instances of this directly, use the NewRegistryTool function instead.
+type RegistryToolBuilder struct {
+	logger        logr.Logger
+	client        *Client
+	configName    string
+	configmapName string
+}
+
+// RegistryTool is a tool that knows how to perform tasks related to image registries. For example,
+// it knows how to add a trusted registry to an OpenShift cluster. Don't create instances of this
+// directly, use the NewRegistryTool function instead.
+type RegistryTool struct {
+	logger        logr.Logger
+	client        *Client
+	configName    string
+	configmapName string
+	jq            *jq.Tool
+}
+
+// NewRegistryTool creates a builder that can then be used to configure and create an instance of
+// the registry tool.
+func NewRegistryTool() *RegistryToolBuilder {
+	return &RegistryToolBuilder{
+		configName:    registryToolDefaultConfigName,
+		configmapName: registryToolDefaultConfigmapName,
+	}
+}
+
+// SetLogger sets the logger that the tool will use to write messages to the log. This is mandatory.
+func (b *RegistryToolBuilder) SetLogger(value logr.Logger) *RegistryToolBuilder {
+	b.logger = value
+	return b
+}
+
+// SetClient sets the Kubernetes API client that the tool will use to interact with the cluster.
+// This is mandatory.
+func (b *RegistryToolBuilder) SetClient(value *Client) *RegistryToolBuilder {
+	b.client = value
+	return b
+}
+
+// SetConfigName sets the name of the image configuration object that will be updated. The default
+// is to use `cluster` and there is usually no reason to change it, as that is the name used by
+// OpenShift. This is intended for use in unit tests where it is convenient to use a different name.
+func (b *RegistryToolBuilder) SetConfigName(value string) *RegistryToolBuilder {
+	b.configName = value
+	return b
+}
+
+// SetConfigmapName sets the name of the CA configmap object that will created if it doesn't exist.
+// The default is to use the `registry-cas` and there is usually no reason to change it. This is
+// intended for use in unit tests where it is convenient to use a different name.
+func (b *RegistryToolBuilder) SetConfigmapName(value string) *RegistryToolBuilder {
+	b.configmapName = value
+	return b
+}
+
+// Build uses the data stored in the buider to create a new instance of the registry tool.
+func (b *RegistryToolBuilder) Build() (result *RegistryTool, err error) {
+	// Check parameters:
+	if b.logger.GetSink() == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.client == nil {
+		err = errors.New("client is mandatory")
+		return
+	}
+
+	// Warn if custom object names have been specified, as that is intended only for unit tests:
+	if b.configName != "" {
+		b.logger.Info(
+			"Using custom image configuration object name is intended only for unit tests",
+			"name", b.configName,
+		)
+	}
+	if b.configmapName != "" {
+		b.logger.Info(
+			"Using custom CA configmap name is intended only for unit tests",
+			"name", b.configmapName,
+		)
+	}
+
+	// Create the jq tool:
+	jqTool, err := jq.NewTool().
+		SetLogger(b.logger).
+		Build()
+	if err != nil {
+		err = fmt.Errorf("failed to create jq tool: %v", err)
+		return
+	}
+
+	// Create and populate the object:
+	result = &RegistryTool{
+		logger:        b.logger,
+		client:        b.client,
+		configName:    b.configName,
+		configmapName: b.configmapName,
+		jq:            jqTool,
+	}
+	return
+}
+
+// AddTrustedRegistry sets the given server as an additional trusted registry.
+func (t *RegistryTool) AddTrustedRegistry(ctx context.Context, server string, ca []byte) error {
+	var err error
+
+	// Fetch the CA for the sever if not explicitly passed:
+	if ca == nil {
+		ca, err = t.fetchCA(server)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Get the name of the configmap that is currently used for additional trusted registry
+	// certificate authorities:
+	configObject := &unstructured.Unstructured{}
+	configObject.SetGroupVersionKind(ImageConfigGVK)
+	configKey := clnt.ObjectKey{
+		Name: t.configName,
+	}
+	err = t.client.Get(ctx, configKey, configObject)
+	if err != nil {
+		return err
+	}
+	var configmapName string
+	err = t.jq.Query(`.spec.additionalTrustedCA.name`, configObject, &configmapName)
+	if err != nil {
+		return err
+	}
+
+	// If there are already additional trusted CAs then load them:
+	var configmapData map[string]string
+	configmapObject := &corev1.ConfigMap{}
+	configmapKey := clnt.ObjectKey{
+		Namespace: "openshift-config",
+		Name:      configmapName,
+	}
+	if configmapName != "" {
+		err = t.client.Get(ctx, configmapKey, configmapObject)
+		switch {
+		case err == nil:
+			configmapData = configmapObject.Data
+		case apierrors.IsNotFound(err):
+		default:
+			return err
+		}
+	}
+	if configmapData == nil {
+		configmapData = map[string]string{}
+	}
+
+	// Check if our registry is already in the list:
+	serverKey, err := t.configKey(server)
+	if err != nil {
+		return err
+	}
+	serverCA, ok := configmapData[serverKey]
+	if ok && bytes.Equal(ca, []byte(serverCA)) {
+		t.logger.Info(
+			"Trusted registry is already configured",
+			"registry", server,
+		)
+		return nil
+	}
+
+	// Create or update the configmap containing the additional trusted registry certificates:
+	if configmapObject.CreationTimestamp.IsZero() {
+		configmapObject.Namespace = "openshift-config"
+		configmapObject.Name = t.configmapName
+		configmapObject.Data = map[string]string{
+			serverKey: string(ca),
+		}
+		err = t.client.Create(ctx, configmapObject)
+		if err != nil {
+			return err
+		}
+		t.logger.Info(
+			"Created trusted registry configmap",
+			"registry", server,
+			"configmap", configmapKey,
+		)
+	} else {
+		configmapUpdate := configmapObject.DeepCopy()
+		if configmapUpdate.Data == nil {
+			configmapUpdate.Data = map[string]string{}
+		}
+		configmapUpdate.Data[serverKey] = string(ca)
+		err = t.client.Patch(ctx, configmapUpdate, clnt.MergeFrom(configmapObject))
+		if err != nil {
+			return err
+		}
+		t.logger.Info(
+			"Updated trusted registry configmap",
+			"registry", server,
+			"configmap", configmapKey,
+		)
+	}
+
+	// Update the image configuration:
+	if configmapName != configmapObject.GetName() {
+		imageConfigUpdate := configObject.DeepCopy()
+		err = mergo.MergeWithOverwrite(&imageConfigUpdate.Object, map[string]any{
+			"spec": map[string]any{
+				"additionalTrustedCA": map[string]any{
+					"name": configmapObject.GetName(),
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		err = t.client.Patch(ctx, imageConfigUpdate, clnt.MergeFrom(configObject))
+		if err != nil {
+			return err
+		}
+		t.logger.Info(
+			"Updated image configuration to trust registry",
+			"registry", server,
+		)
+	}
+
+	return nil
+}
+
+// configKey calculates the key that is used in the configmap that contains the certificates of the
+// additional trusted registries. This key is the registry host followed by two dots and the port
+// number. These two dots and the port number are optional and only used when the port isn't 443.
+// For example, if the server address is `my.registry.com:5000` then the key is
+// `my.registry.com..5000`.
+func (t *RegistryTool) configKey(address string) (result string, err error) {
+	host, port, err := net.SplitHostPort(address)
+	if t.isMissingPort(err) {
+		result = address
+		err = nil
+		return
+	}
+	if err != nil {
+		return
+	}
+	if port == "443" {
+		result = host
+	} else {
+		result = fmt.Sprintf("%s..%s", host, port)
+	}
+	return
+}
+
+// fetchCA fetches the CA certificate from the given address.
+func (t *RegistryTool) fetchCA(address string) (result []byte, err error) {
+	// Set the default port:
+	_, _, err = net.SplitHostPort(address)
+	if t.isMissingPort(err) {
+		address += ":443"
+	}
+
+	// Connect to the server and do the TLS handshake to obtain the certificate chain:
+	conn, err := tls.Dial("tcp", address, &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	certs := conn.ConnectionState().PeerCertificates
+
+	// Serialize the certificates:
+	buffer := &bytes.Buffer{}
+	for _, cert := range certs {
+		err = pem.Encode(buffer, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		})
+		if err != nil {
+			return
+		}
+	}
+	result = buffer.Bytes()
+
+	return
+}
+
+func (t *RegistryTool) isMissingPort(err error) bool {
+	addrErr, ok := err.(*net.AddrError)
+	if ok {
+		return addrErr.Err == "missing port in address"
+	}
+	return false
+}
+
+// Default values:
+const (
+	registryToolDefaultConfigName    = "cluster"
+	registryToolDefaultConfigmapName = "registry-cas"
+)

--- a/ztp/internal/registry_tool_test.go
+++ b/ztp/internal/registry_tool_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
+*/
+
+package internal
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/imdario/mergo"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/jq"
+	"github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/ztp/internal/logging"
+)
+
+var _ = Describe("Registry tool", func() {
+	var (
+		ctx    context.Context
+		logger logr.Logger
+		client *Client
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Create the logger:
+		logger, err = logging.NewLogger().
+			SetWriter(GinkgoWriter).
+			SetLevel(2).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the client:
+		client, err = NewClient().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		// Close the client:
+		err := client.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Creation", func() {
+		It("Can't be created without a logger", func() {
+			tool, err := NewRegistryTool().
+				SetClient(client).
+				Build()
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("logger"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+			Expect(tool).To(BeNil())
+		})
+
+		It("Can't be created without a client", func() {
+			tool, err := NewRegistryTool().
+				SetLogger(logger).
+				Build()
+			Expect(err).To(HaveOccurred())
+			msg := err.Error()
+			Expect(msg).To(ContainSubstring("client"))
+			Expect(msg).To(ContainSubstring("mandatory"))
+			Expect(tool).To(BeNil())
+		})
+	})
+
+	Describe("Add trusted registry", func() {
+		var (
+			randomName   string
+			jqTool       *jq.Tool
+			registryTool *RegistryTool
+		)
+
+		BeforeEach(func() {
+			// Generate a random name for the image configuration object and for the CA
+			// configmap:
+			randomName = fmt.Sprintf("my-%s", uuid.NewString())
+
+			// Create the image configuration object:
+			configObject := &unstructured.Unstructured{}
+			configObject.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "config.openshift.io",
+				Version: "v1",
+				Kind:    "Image",
+			})
+			configObject.SetName(randomName)
+			configObject.Object["spec"] = map[string]any{}
+			err := client.Create(ctx, configObject)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the JQ tool:
+			jqTool, err = jq.NewTool().
+				SetLogger(logger).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the tool:
+			registryTool, err = NewRegistryTool().
+				SetLogger(logger).
+				SetClient(client).
+				SetConfigName(randomName).
+				SetConfigmapName(randomName).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			var err error
+
+			// Delete the image configObject object:
+			configObject := &unstructured.Unstructured{}
+			configObject.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "config.openshift.io",
+				Version: "v1",
+				Kind:    "Image",
+			})
+			configObject.SetName(randomName)
+			err = client.Delete(ctx, configObject)
+			if apierrors.IsNotFound(err) {
+				err = nil
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			// Delete the configmapObject:
+			configmapObject := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "openshift-config",
+					Name:      randomName,
+				},
+			}
+			err = client.Delete(ctx, configmapObject)
+			if apierrors.IsNotFound(err) {
+				err = nil
+			}
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Adds first trusted registry", func() {
+			// Add the registry:
+			err := registryTool.AddTrustedRegistry(
+				ctx,
+				"my.registry.com",
+				[]byte("my-ca"),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the image config has been updated:
+			configObject := &unstructured.Unstructured{}
+			configObject.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "config.openshift.io",
+				Version: "v1",
+				Kind:    "Image",
+			})
+			configKey := clnt.ObjectKey{
+				Name: randomName,
+			}
+			err = client.Get(ctx, configKey, configObject)
+			Expect(err).ToNot(HaveOccurred())
+			var configmapName string
+			err = jqTool.Query(
+				`.spec.additionalTrustedCA.name`,
+				configObject.Object, &configmapName,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configmapName).To(Equal(randomName))
+
+			// Check that the CA has been added to the configmap:
+			configmapObject := corev1.ConfigMap{}
+			configmapKey := clnt.ObjectKey{
+				Namespace: "openshift-config",
+				Name:      randomName,
+			}
+			err = client.Get(ctx, configmapKey, &configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configmapObject.Data).To(
+				HaveKeyWithValue("my.registry.com", "my-ca"),
+			)
+		})
+
+		It("Adds CA to existing configmap", func() {
+			// Create the configmap:
+			configmapObject := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    "openshift-config",
+					GenerateName: "your-",
+				},
+				Data: map[string]string{
+					"your.registry.com": "your-ca",
+				},
+			}
+			err := client.Create(ctx, configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err := client.Delete(ctx, configmapObject)
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			// Update the image config:
+			configObject := &unstructured.Unstructured{}
+			configObject.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "config.openshift.io",
+				Version: "v1",
+				Kind:    "Image",
+			})
+			configKey := clnt.ObjectKey{
+				Name: randomName,
+			}
+			err = client.Get(ctx, configKey, configObject)
+			Expect(err).ToNot(HaveOccurred())
+			configUpdate := configObject.DeepCopy()
+			err = mergo.MapWithOverwrite(&configUpdate.Object, map[string]any{
+				"spec": map[string]any{
+					"additionalTrustedCA": map[string]any{
+						"name": configmapObject.Name,
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			err = client.Patch(ctx, configUpdate, clnt.MergeFrom(configObject))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Add the registry:
+			err = registryTool.AddTrustedRegistry(ctx, "my.registry.com", []byte("my-ca"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the image configuration hasn't changed:
+			err = client.Get(ctx, configKey, configObject)
+			Expect(err).ToNot(HaveOccurred())
+			var configmapName string
+			err = jqTool.Query(
+				`.spec.additionalTrustedCA.name`,
+				configObject, &configmapName,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configmapName).To(Equal(configmapObject.Name))
+
+			// Check that the new CA has been added to the configmap and that the
+			// existing one has been preserved:
+			configmapKey := clnt.ObjectKeyFromObject(configmapObject)
+			err = client.Get(ctx, configmapKey, configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configmapObject.Data).To(
+				HaveKeyWithValue("my.registry.com", "my-ca"),
+			)
+			Expect(configmapObject.Data).To(
+				HaveKeyWithValue("your.registry.com", "your-ca"),
+			)
+		})
+
+		It("Replaces existing CA", func() {
+			// Create the configmap:
+			configmapObject := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "openshift-config",
+					Name:      randomName,
+				},
+				Data: map[string]string{
+					"my.registry.com": "my-old-ca",
+				},
+			}
+			err := client.Create(ctx, configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err := client.Delete(ctx, configmapObject)
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			// Update the image config:
+			configObject := &unstructured.Unstructured{}
+			configObject.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "config.openshift.io",
+				Version: "v1",
+				Kind:    "Image",
+			})
+			configKey := clnt.ObjectKey{
+				Name: randomName,
+			}
+			err = client.Get(ctx, configKey, configObject)
+			Expect(err).ToNot(HaveOccurred())
+			configUpdate := configObject.DeepCopy()
+			err = mergo.MapWithOverwrite(&configUpdate.Object, map[string]any{
+				"spec": map[string]any{
+					"additionalTrustedCA": map[string]any{
+						"name": configmapObject.Name,
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			err = client.Patch(ctx, configUpdate, clnt.MergeFrom(configObject))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Add the registry, but with a different CA certificate:
+			err = registryTool.AddTrustedRegistry(ctx, "my.registry.com", []byte("my-new-ca"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the CA has been replaced:
+			configmapKey := clnt.ObjectKeyFromObject(configmapObject)
+			err = client.Get(ctx, configmapKey, configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configmapObject.Data).To(
+				HaveKeyWithValue("my.registry.com", "my-new-ca"),
+			)
+		})
+
+		It("Generates configmap key with two dots when port explicitly set", func() {
+			// Add the registry:
+			err := registryTool.AddTrustedRegistry(ctx, "my.registry.com:5000", []byte("my-ca"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the CA has been added with the right key:
+			configmapObject := &corev1.ConfigMap{}
+			configmapKey := clnt.ObjectKey{
+				Namespace: "openshift-config",
+				Name:      randomName,
+			}
+			err = client.Get(ctx, configmapKey, configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configmapObject.Data).To(
+				HaveKeyWithValue("my.registry.com..5000", "my-ca"),
+			)
+		})
+
+		It("Fetches CA from server if not explicitly passed", func() {
+			// Create the server:
+			server := NewTLSServer()
+			defer func() {
+				server.Close()
+			}()
+
+			// Add the registry:
+			err := registryTool.AddTrustedRegistry(ctx, server.Addr(), nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the CA has been added:
+			configmapObject := &corev1.ConfigMap{}
+			configmapKey := clnt.ObjectKey{
+				Namespace: "openshift-config",
+				Name:      randomName,
+			}
+			err = client.Get(ctx, configmapKey, configmapObject)
+			Expect(err).ToNot(HaveOccurred())
+			serverHost, serverPort, err := net.SplitHostPort(server.Addr())
+			Expect(err).ToNot(HaveOccurred())
+			serverKey := fmt.Sprintf("%s..%s", serverHost, serverPort)
+			Expect(configmapObject.Data).To(HaveKey(serverKey))
+
+			// Check that the CA can be used to connect to the server:
+			serverCA := []byte(configmapObject.Data[serverKey])
+			caPool := x509.NewCertPool()
+			ok := caPool.AppendCertsFromPEM(serverCA)
+			Expect(ok).To(BeTrue())
+			conn, err := tls.Dial(
+				"tcp",
+				server.Addr(),
+				&tls.Config{
+					RootCAs: caPool,
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err := conn.Close()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+		})
+	})
+})


### PR DESCRIPTION
# Description

This patch adds a new `RegistryTool` object that simplifies certain image registry tasks. For example, it simplifies adding a trusted registry CA to an OpenShift cluster.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
