### PR TITLE
NO-ISSUE: Remove warn of custom names in registry tool

### DIFF
--- a/ztp/internal/registry_tool.go
+++ b/ztp/internal/registry_tool.go
@@ -102,20 +102,6 @@ func (b *RegistryToolBuilder) Build() (result *RegistryTool, err error) {
 		return
 	}
 
-	// Warn if custom object names have been specified, as that is intended only for unit tests:
-	if b.configName != "" {
-		b.logger.Info(
-			"Using custom image configuration object name is intended only for unit tests",
-			"name", b.configName,
-		)
-	}
-	if b.configmapName != "" {
-		b.logger.Info(
-			"Using custom CA configmap name is intended only for unit tests",
-			"name", b.configmapName,
-		)
-	}
-
 	// Create the jq tool:
 	jqTool, err := jq.NewTool().
 		SetLogger(b.logger).


### PR DESCRIPTION
# Description

This patch removes the warning that the registry tool generates when custom object names are used. That doesn't work because the checked names will always have a value, even if it is the default. There is not much value in that chec, so it is OK to remove it.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
