### PR TITLE
NO-ISSUE: Improve registry tool

### DIFF
--- a/ztp/internal/cmd/icsp/create_icsp_cmd.go
+++ b/ztp/internal/cmd/icsp/create_icsp_cmd.go
@@ -252,9 +252,24 @@ func (t *CreateTask) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = registryTool.AddTrustedRegistry(ctx, t.cluster.Registry.URL, t.cluster.Registry.CA)
+	trusted, err := registryTool.IsTrusted(ctx, t.cluster.Registry.URL, t.cluster.Registry.CA)
 	if err != nil {
 		return err
+	}
+	if trusted {
+		t.console.Warn(
+			"Registry '%s' is already trusted in cluster '%s'",
+			t.cluster.Registry.URL, t.cluster.Name,
+		)
+	} else {
+		err = registryTool.AddTrusted(ctx, t.cluster.Registry.URL, t.cluster.Registry.CA)
+		if err != nil {
+			return err
+		}
+		t.console.Info(
+			"Added trusted registry '%s' to cluster '%s'",
+			t.cluster.Registry.URL, t.cluster.Name,
+		)
 	}
 
 	// Create the image content source policies:


### PR DESCRIPTION
# Description

This patch adds to the registry tool the capability to check if a registry is already trusted. This will be used to avoid changing the configuration when it is already modified.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
