### PR TITLE
Revert pipeline changes to use CLI

### DIFF
--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
+    - name: ztp-log-level
       type: string
-      default: ""
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -56,8 +56,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:
@@ -71,14 +71,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -93,14 +93,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -114,14 +114,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-metallb
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -15,9 +15,6 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
-      type: string
-      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -56,8 +53,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -134,14 +134,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-metallb
     workspaces:
@@ -155,14 +155,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-lso
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
@@ -137,14 +137,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-lvmo
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
+    - name: ztp-log-level
       type: string
-      default: ""
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -56,8 +56,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:
@@ -79,8 +79,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -95,19 +93,20 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:
       - name: ztp
         workspace: ztp
+
 
   # Deploy LVMO
   - name: deploy-lvmo

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
@@ -158,14 +158,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-lvmo
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno-connected.yaml
@@ -15,9 +15,6 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
-      type: string
-      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -56,8 +53,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
+    - name: ztp-log-level
       type: string
-      default: ""
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -57,8 +57,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:
@@ -80,8 +80,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -96,19 +94,20 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:
       - name: ztp
         workspace: ztp
+
 
   # Deploy LVMO
   - name: deploy-lvmo

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -159,14 +159,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-lvmo
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -138,14 +138,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-lvmo
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-sno.yaml
@@ -15,9 +15,6 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
-      type: string
-      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -57,8 +54,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -137,14 +137,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-metallb
     workspaces:
@@ -158,14 +158,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-lso
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -15,12 +15,6 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
-      type: string
-      default: "0"
-    - name: ztp-log-level
-      type: string
-      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -60,8 +54,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-log-level
-        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -117,14 +117,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-metallb
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -15,9 +15,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
+    - name: ztp-log-level
       type: string
-      default: ""
+      default: "0"
   workspaces:
     - name: ztp
   tasks:
@@ -57,8 +57,8 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
+      - name: ztp-log-level
+        value: $(params.ztp-log-level)
     runAfter:
       - pre-flight
     workspaces:
@@ -80,8 +80,6 @@ spec:
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-edgeclusters
     workspaces:
@@ -96,14 +94,14 @@ spec:
     params:
       - name: edgeclusters-config
         value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
       - name: ztp-container-image
         value: $(params.ztp-container-image)
       - name: mock
         value: $(params.mock)
       - name: pipeline-name
         value: $(context.pipelineRun.name)
-      - name: ztp-extra-args
-        value: $(params.ztp-extra-args)
     runAfter:
       - deploy-icsp-edgeclusters-pre
     workspaces:

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -18,6 +18,9 @@ spec:
     - name: ztp-log-level
       type: string
       default: "0"
+    - name: ztp-log-level
+      type: string
+      default: "0"
   workspaces:
     - name: ztp
   tasks:

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: kubeconfig
+      type: string
+      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -21,14 +24,37 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-log-level
-      type: string
-      default: "0"
   stepTemplate:
     env:
+      - name: WORKDIR
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
+      - name: EDGECLUSTERS_CONFIG
+        value: $(params.edgeclusters-config)
+      - name: KUBECONFIG
+        value: "$(workspaces.ztp.path)/kubeconfig"
+      - name: DEPLOY_EDGECLUSTERS_DIR
+        value: "deploy-edgecluster"
+      - name: SHARED_DIR
+        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
+    - name: render-edgeclusters
+      image: "$(params.ztp-container-image)"
+      imagePullPolicy: Always
+      script: |
+        #!/usr/bin/bash
+
+        if [[ "${MOCK}" == 'false' ]]; then
+          cd ${WORKDIR}/${DEPLOY_EDGECLUSTERS_DIR}
+          ./render_edgeclusters.sh
+          sleep 3
+        else
+          echo "Render Edge-cluster: Mock mode on"
+        fi
+
     - name: deploy-edgeclusters
       image: "$(params.ztp-container-image)"
       imagePullPolicy: Always
@@ -36,13 +62,8 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          ztp create clusters \
-          --config "$(params.edgeclusters-config)" \
-          --output "/workspace/ztp/$(params.pipeline-name)" \
-          --mute \
-          --log-file "stdout" \
-          --log-level "$(params.ztp-log-level)" \
-          --wait "2h30m"
+          cd ${WORKDIR}/${DEPLOY_EDGECLUSTERS_DIR}
+          ./deploy.sh
         else
           echo "Deploy Edge-cluster: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-edgecluster.yaml
@@ -21,9 +21,9 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
+    - name: ztp-log-level
       type: string
-      default: ""
+      default: "0"
   stepTemplate:
     env:
       - name: MOCK
@@ -39,10 +39,10 @@ spec:
           ztp create clusters \
           --config "$(params.edgeclusters-config)" \
           --output "/workspace/ztp/$(params.pipeline-name)" \
-          --wait "2h30m" \
-          --log-field "pr=$(params.pipeline-name)" \
-          --log-field "tr=$(context.taskRun.name)" \
-          $(params.ztp-extra-args)
+          --mute \
+          --log-file "stdout" \
+          --log-level "$(params.ztp-log-level)" \
+          --wait "2h30m"
         else
           echo "Deploy Edge-cluster: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-icsp-edgeclusters-pre.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: kubeconfig
+      type: string
+      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -21,11 +24,22 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
-      type: string
-      default: ""
   stepTemplate:
     env:
+      - name: WORKDIR
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
+      - name: EDGECLUSTERS_CONFIG
+        value: $(params.edgeclusters-config)
+      - name: KUBECONFIG
+        value: "$(workspaces.ztp.path)/kubeconfig"
+      - name: DEPLOY_EDGECLUSTERS_DIR
+        value: "deploy-edgecluster"
+      - name: DEPLOY_REGISTRY_DIR
+        value: "deploy-disconnected-registry"
+      - name: SHARED_DIR
+        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
@@ -36,11 +50,8 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          ztp create icsps \
-          --config "$(params.edgeclusters-config)" \
-          --log-field "pr=$(params.pipeline-name)" \
-          --log-field "tr=$(context.taskRun.name)" \
-          $(params.ztp-extra-args)
+          cd ${WORKDIR}/${DEPLOY_EDGECLUSTERS_DIR}
+          ./configure_disconnected.sh 'edgecluster' 'pre'
         else
           echo "Deploy ICSP Pre: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-lso.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-lso.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: kubeconfig
+      type: string
+      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -21,11 +24,20 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
-      type: string
-      default: ""
   stepTemplate:
     env:
+      - name: WORKDIR
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
+      - name: EDGECLUSTERS_CONFIG
+        value: $(params.edgeclusters-config)
+      - name: KUBECONFIG
+        value: "$(workspaces.ztp.path)/kubeconfig"
+      - name: DEPLOY_ODF_DIR
+        value: "deploy-lso"
+      - name: SHARED_DIR
+        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
@@ -36,11 +48,8 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          ztp create lso \
-          --config "$(params.edgeclusters-config)" \
-          --log-field "pr=$(params.pipeline-name)" \
-          --log-field "tr=$(context.taskRun.name)" \
-          $(params.ztp-extra-args)
+          cd ${WORKDIR}/${DEPLOY_ODF_DIR}
+          ./deploy.sh
         else
-          echo "Deploy LSO: Mock mode on"
+          echo "Deploy ODF: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-metallb.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: kubeconfig
+      type: string
+      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -21,9 +24,22 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
-      type: string
-      default: ""
+  stepTemplate:
+    env:
+      - name: WORKDIR
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
+      - name: EDGECLUSTERS_CONFIG
+        value: $(params.edgeclusters-config)
+      - name: KUBECONFIG
+        value: "$(workspaces.ztp.path)/kubeconfig"
+      - name: DEPLOY_METALLB_DIR
+        value: "deploy-metallb"
+      - name: SHARED_DIR
+        value: "shared-utils"
+      - name: MOCK
+        value: $(params.mock)
   steps:
     - name: deploy-metallb
       image: "$(params.ztp-container-image)"
@@ -31,13 +47,9 @@ spec:
       script: |
         #!/usr/bin/bash
 
-        if [[ "$(params.mock)" == 'false' ]]; then
-          ztp create metallbs \
-          --config "$(params.edgeclusters-config)" \
-          --log-field "$(params.pipeline-name)" \
-          --log-field "$(context.taskRun.name)" \
-          --wait "30m" \
-          $(params.ztp-extra-args)
+        if [[ "${MOCK}" == 'false' ]]; then
+          cd ${WORKDIR}/${DEPLOY_METALLB_DIR}
+          ./deploy.sh
         else
           echo "Deploy MetalLB: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-odf.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-odf.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: kubeconfig
+      type: string
+      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -21,11 +24,20 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
-      type: string
-      default: ""
   stepTemplate:
     env:
+      - name: WORKDIR
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
+      - name: EDGECLUSTERS_CONFIG
+        value: $(params.edgeclusters-config)
+      - name: KUBECONFIG
+        value: "$(workspaces.ztp.path)/kubeconfig"
+      - name: DEPLOY_ODF_DIR
+        value: "deploy-odf"
+      - name: SHARED_DIR
+        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
@@ -36,11 +48,8 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          ztp create odf \
-          --config "$(params.edgeclusters-config)" \
-          --log-field "pr=$(params.pipeline-name)" \
-          --log-field "tr=$(context.taskRun.name)" \
-          $(params.ztp-extra-args)
+          cd ${WORKDIR}/${DEPLOY_ODF_DIR}
+          ./deploy.sh
         else
           echo "Deploy ODF: Mock mode on"
         fi

--- a/pipelines/resources/edgeclusters/edgecluster-deploy-ui.yaml
+++ b/pipelines/resources/edgeclusters/edgecluster-deploy-ui.yaml
@@ -12,6 +12,9 @@ spec:
     - name: ztp-container-image
       type: string
       default: "quay.io/ztpfw/pipeline:latest"
+    - name: kubeconfig
+      type: string
+      default: ""
     - name: pipeline-name
       type: string
       default: $(context.taskRun.name)
@@ -21,11 +24,20 @@ spec:
     - name: mock
       type: string
       default: "false"
-    - name: ztp-extra-args
-      type: string
-      default: ""
   stepTemplate:
     env:
+      - name: WORKDIR
+        value: "/workspace/ztp/$(params.pipeline-name)"
+      - name: OUTPUTDIR
+        value: "/workspace/ztp/$(params.pipeline-name)/build/$(context.taskRun.name)"
+      - name: EDGECLUSTERS_CONFIG
+        value: $(params.edgeclusters-config)
+      - name: KUBECONFIG
+        value: "$(workspaces.ztp.path)/kubeconfig"
+      - name: DEPLOY_UI_DIR
+        value: "deploy-ui"
+      - name: SHARED_DIR
+        value: "shared-utils"
       - name: MOCK
         value: $(params.mock)
   steps:
@@ -36,11 +48,8 @@ spec:
         #!/usr/bin/bash
 
         if [[ "${MOCK}" == 'false' ]]; then
-          ztp create ui \
-          --config "$(params.edgeclusters-config)" \
-          --log-field "pr=$(params.pipeline-name)" \
-          --log-field "tr=$(context.taskRun.name)" \
-          $(params.ztp-extra-args)
+          cd ${WORKDIR}/${DEPLOY_UI_DIR}
+          ./deploy.sh
         else
           echo "Deploy UI: Mock mode on"
         fi


### PR DESCRIPTION
# Description

These patches revert the changes that have been made to the pipeline in order to use the `ztp` command instead of the shell scripts.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
