### PR TITLE
NO-ISSUE: Revert remove deploy workers

### DIFF
--- a/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters-connected.yaml
@@ -102,6 +102,27 @@ spec:
       - name: ztp
         workspace: ztp
 
+  # Deploy Workers
+  - name: deploy-workers
+    taskRef:
+      name: edgecluster-deploy-workers
+    params:
+      - name: edgeclusters-config
+        value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
+      - name: ztp-container-image
+        value: $(params.ztp-container-image)
+      - name: mock
+        value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
+    runAfter:
+      - deploy-metallb
+    workspaces:
+      - name: ztp
+        workspace: ztp
+
   # Deploy ZTPFWUI
   - name: deploy-ui
     taskRef:
@@ -138,7 +159,7 @@ spec:
       - name: pipeline-name
         value: $(context.pipelineRun.name)
     runAfter:
-      - deploy-metallb
+      - deploy-workers
     workspaces:
       - name: ztp
         workspace: ztp

--- a/pipelines/resources/deploy-ztp-edgeclusters.yaml
+++ b/pipelines/resources/deploy-ztp-edgeclusters.yaml
@@ -103,6 +103,27 @@ spec:
       - name: ztp
         workspace: ztp
 
+  # Deploy Workers
+  - name: deploy-workers
+    taskRef:
+      name: edgecluster-deploy-workers
+    params:
+      - name: edgeclusters-config
+        value: $(params.edgeclusters-config)
+      - name: kubeconfig
+        value: $(params.kubeconfig)
+      - name: ztp-container-image
+        value: $(params.ztp-container-image)
+      - name: mock
+        value: $(params.mock)
+      - name: pipeline-name
+        value: $(context.pipelineRun.name)
+    runAfter:
+      - deploy-metallb
+    workspaces:
+      - name: ztp
+        workspace: ztp
+
   # Deploy ZTPFWUI
   - name: deploy-ui
     taskRef:
@@ -139,7 +160,7 @@ spec:
       - name: pipeline-name
         value: $(context.pipelineRun.name)
     runAfter:
-      - deploy-metallb
+      - deploy-workers
     workspaces:
       - name: ztp
         workspace: ztp


### PR DESCRIPTION
# Description

In pull request #162 we removed the step to deploy worker nodes from the pipeline because with OpenShift 4.12 it is no longer necessary: the worker nodes can be created from the beginning. But the fixes needed to support that were done only to the CLI, which was since then removed from the pipeline. This patch reverts those changes to the pipeline.

Related: https://github.com/rh-ecosystem-edge/ztp-pipeline-relocatable/pull/162

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
